### PR TITLE
feat(T06): rate limit defense + error handling

### DIFF
--- a/internal/live/proxy.go
+++ b/internal/live/proxy.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Two-Weeks-Team/missless/internal/util"
 	"github.com/gorilla/websocket"
 )
 
@@ -34,14 +35,14 @@ func (p *Proxy) Run(ctx context.Context) {
 	defer p.mu.Unlock()
 
 	p.wg.Add(2)
-	go func() {
+	util.SafeGo(func() {
 		defer p.wg.Done()
 		p.forwardBrowserToLive(ctx)
-	}()
-	go func() {
+	})
+	util.SafeGo(func() {
 		defer p.wg.Done()
 		p.forwardLiveToBrowser(ctx)
-	}()
+	})
 }
 
 // forwardBrowserToLive reads from browser WebSocket and sends to Live API.

--- a/internal/middleware/timeout.go
+++ b/internal/middleware/timeout.go
@@ -1,0 +1,17 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// Timeout wraps a handler with a context deadline.
+// If the handler exceeds the given duration, the context is cancelled.
+func Timeout(d time.Duration, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), d)
+		defer cancel()
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/internal/middleware/timeout_test.go
+++ b/internal/middleware/timeout_test.go
@@ -1,0 +1,65 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestTimeout_NormalRequest(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	handler := Timeout(10*time.Second, inner)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestTimeout_ContextHasDeadline(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deadline, ok := r.Context().Deadline()
+		if !ok {
+			t.Fatal("expected context to have deadline")
+		}
+		if time.Until(deadline) > 10*time.Second {
+			t.Fatalf("deadline too far in future: %v", time.Until(deadline))
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := Timeout(10*time.Second, inner)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestTimeout_ContextCancelledOnExpiry(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+			// Context was cancelled by timeout
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected context to be cancelled before 2s")
+		}
+	})
+
+	handler := Timeout(50*time.Millisecond, inner)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+}

--- a/internal/retry/backoff.go
+++ b/internal/retry/backoff.go
@@ -43,7 +43,7 @@ func WithBackoff(ctx context.Context, maxRetries int, fn func() error) error {
 
 func calculateDelay(attempt int) time.Duration {
 	base := math.Pow(2, float64(attempt)) * float64(time.Second)
-	jitter := rand.Float64() * float64(time.Second)
+	jitter := rand.Float64() * base * 0.5 // 0~50% of base delay
 	delay := time.Duration(base) + time.Duration(jitter)
 
 	maxDelay := 30 * time.Second

--- a/internal/retry/backoff_test.go
+++ b/internal/retry/backoff_test.go
@@ -93,3 +93,28 @@ func TestCalculateDelay_Bounds(t *testing.T) {
 		}
 	}
 }
+
+func TestCalculateDelay_JitterRange(t *testing.T) {
+	// For attempt 0: base = 1s, jitter = 0~0.5s → total = 1s~1.5s
+	// For attempt 1: base = 2s, jitter = 0~1s   → total = 2s~3s
+	// For attempt 2: base = 4s, jitter = 0~2s   → total = 4s~6s
+	cases := []struct {
+		attempt int
+		minD    time.Duration
+		maxD    time.Duration
+	}{
+		{0, 1 * time.Second, 1500 * time.Millisecond},
+		{1, 2 * time.Second, 3 * time.Second},
+		{2, 4 * time.Second, 6 * time.Second},
+	}
+
+	for _, tc := range cases {
+		for range 100 {
+			d := calculateDelay(tc.attempt)
+			if d < tc.minD || d > tc.maxD {
+				t.Fatalf("attempt %d: delay %v out of range [%v, %v]",
+					tc.attempt, d, tc.minD, tc.maxD)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Fix backoff jitter calculation to use 0~50% of base delay (was fixed 0~1s)
- Add context Timeout middleware for 10s request deadline enforcement
- Replace bare `go func()` with `util.SafeGo()` in WebSocket proxy goroutines
- Add jitter range validation test and timeout middleware tests

## Issue
Closes #11

## Changes
| File | Change |
|------|--------|
| `internal/retry/backoff.go` | Fix jitter: `rand * base * 0.5` instead of `rand * 1s` |
| `internal/retry/backoff_test.go` | Add `TestCalculateDelay_JitterRange` (100 iterations per case) |
| `internal/live/proxy.go` | Use `util.SafeGo()` in `Run()` for goroutine safety |
| `internal/middleware/timeout.go` | New: context deadline middleware |
| `internal/middleware/timeout_test.go` | New: 3 tests (normal, deadline, expiry) |

## Local CI
- [x] `go vet ./...` passed
- [x] `staticcheck ./...` passed
- [x] `go test -race ./...` passed (25 tests)
- [x] `go build ./...` passed

## Test plan
- `TestCalculateDelay_JitterRange` validates attempt 0→[1s,1.5s], 1→[2s,3s], 2→[4s,6s]
- `TestTimeout_ContextCancelledOnExpiry` verifies context cancellation after 50ms
- Existing backoff/recovery tests continue to pass