### PR TITLE
feat(T04): Next.js PWA renderer with scene crossfade

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -23,3 +23,9 @@ body {
 * {
   box-sizing: border-box;
 }
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useWebSocket, ServerMessage } from '../hooks/useWebSocket';
 import { useAudio } from '../hooks/useAudio';
 import SceneDisplay from '../components/SceneDisplay';
@@ -8,12 +8,20 @@ import SessionTransition from '../components/SessionTransition';
 
 type TransitionPhase = 'idle' | 'transitioning' | 'ready';
 
+const CONNECTION_COLORS: Record<string, string> = {
+  connected: '#4ade80',
+  connecting: '#fbbf24',
+  disconnected: '#ef4444',
+  error: '#ef4444',
+};
+
 export default function Home() {
   const [started, setStarted] = useState(false);
   const [previewSrc, setPreviewSrc] = useState<string | null>(null);
   const [finalSrc, setFinalSrc] = useState<string | null>(null);
   const [transition, setTransition] = useState<TransitionPhase>('idle');
   const [transcript, setTranscript] = useState<string>('');
+  const readyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const { initAudioContext, playPCM, cleanup: cleanupAudio } = useAudio();
 
@@ -33,13 +41,25 @@ export default function Home() {
         break;
       case 'session_ready':
         setTransition('ready');
-        setTimeout(() => setTransition('idle'), 1600);
         break;
       case 'transcript':
         setTranscript(msg.text);
         break;
     }
   }, [playPCM]);
+
+  // Clean up transition timer on unmount or phase change
+  useEffect(() => {
+    if (transition === 'ready') {
+      readyTimerRef.current = setTimeout(() => setTransition('idle'), 1600);
+    }
+    return () => {
+      if (readyTimerRef.current) {
+        clearTimeout(readyTimerRef.current);
+        readyTimerRef.current = null;
+      }
+    };
+  }, [transition]);
 
   const wsUrl = typeof window !== 'undefined'
     ? `ws://${window.location.hostname}:${window.location.port || '18080'}/ws`
@@ -121,7 +141,7 @@ export default function Home() {
             width: 8,
             height: 8,
             borderRadius: '50%',
-            background: state === 'connected' ? '#4ade80' : state === 'connecting' ? '#fbbf24' : '#ef4444',
+            background: CONNECTION_COLORS[state] ?? '#ef4444',
           }}
         />
         <span style={{ fontSize: '0.75rem', color: 'var(--color-muted)' }}>

--- a/web/components/SceneDisplay.tsx
+++ b/web/components/SceneDisplay.tsx
@@ -14,11 +14,16 @@ export default function SceneDisplay({ previewSrc, finalSrc }: SceneDisplayProps
   const finalRef = useRef<HTMLImageElement>(null);
 
   useEffect(() => {
-    if (finalSrc && finalRef.current) {
-      const img = finalRef.current;
-      img.onload = () => setShowFinal(true);
-      img.src = finalSrc;
-    }
+    const img = finalRef.current;
+    if (!finalSrc || !img) return;
+
+    const handleLoad = () => setShowFinal(true);
+    img.addEventListener('load', handleLoad);
+    img.src = finalSrc;
+
+    return () => {
+      img.removeEventListener('load', handleLoad);
+    };
   }, [finalSrc]);
 
   // Reset crossfade when new preview arrives

--- a/web/components/SessionTransition.tsx
+++ b/web/components/SessionTransition.tsx
@@ -17,8 +17,6 @@ export default function SessionTransition({ phase }: SessionTransitionProps) {
     } else if (phase === 'ready') {
       const timer = setTimeout(() => setOpacity(0), 800);
       return () => clearTimeout(timer);
-    } else {
-      setOpacity(0);
     }
   }, [phase]);
 
@@ -64,11 +62,6 @@ export default function SessionTransition({ phase }: SessionTransitionProps) {
           </p>
         )}
       </div>
-      <style>{`
-        @keyframes spin {
-          to { transform: rotate(360deg); }
-        }
-      `}</style>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add SceneDisplay component: preview→final crossfade with 1.2s CSS transition
- Add SessionTransition component: transitioning spinner + ready state UX
- Wire page.tsx with WebSocket hooks, audio playback, scene display, and session transitions
- AudioContext.resume() on user gesture for mobile Chrome compatibility

## Issue
Closes #9

## Changes
| File | Change |
|------|--------|
| `web/components/SceneDisplay.tsx` | New: scene crossfade (preview→final) |
| `web/components/SessionTransition.tsx` | New: transition/ready overlay UX |
| `web/app/page.tsx` | Rewired: WebSocket → audio + scenes + transitions |

## Local CI
- [x] `npx tsc --noEmit` passed
- [x] `npm run lint` passed (no warnings)
- [x] `npm run build` passed (static export)
- [x] `go vet`, `staticcheck`, `go test -race` passed

## Test plan
- `npm run build` produces static export with route `/`
- `npx tsc --noEmit` validates ServerMessage/ClientMessage type consistency
- SceneDisplay renders crossfade between preview and final images
- SessionTransition shows spinner during transition, fades out on ready