### PR TITLE
feat(session): implement Firestore session store and onboarding config (#15)

### DIFF
--- a/internal/handler/websocket.go
+++ b/internal/handler/websocket.go
@@ -76,7 +76,7 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request, cfg *config.Config)
 	toolHandler.SetGenerator(sceneGen)
 
 	// Connect to Live API with onboarding config and retry
-	liveConfig := buildOnboardingConfig()
+	liveConfig := mgr.BuildOnboardingConfig()
 	var liveSession *genai.Session
 	err = retry.WithBackoff(ctx, 3, func() error {
 		var connectErr error
@@ -109,111 +109,4 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request, cfg *config.Config)
 	defer shutdownCancel()
 	mgr.Shutdown(shutdownCtx)
 	slog.Info("session_ended", "remote", r.RemoteAddr)
-}
-
-// buildOnboardingConfig creates the Live API config for the onboarding phase.
-func buildOnboardingConfig() *genai.LiveConnectConfig {
-	return &genai.LiveConnectConfig{
-		ResponseModalities: []genai.Modality{genai.ModalityAudio, genai.ModalityText},
-		SpeechConfig: &genai.SpeechConfig{
-			VoiceConfig: &genai.VoiceConfig{
-				PrebuiltVoiceConfig: &genai.PrebuiltVoiceConfig{
-					VoiceName: "Aoede",
-				},
-			},
-		},
-		SystemInstruction: &genai.Content{
-			Parts: []*genai.Part{
-				genai.NewPartFromText(`You are a warm, empathetic AI guide for missless - a virtual reunion experience.
-You help users reconnect with people they miss through AI-powered conversations.
-
-During onboarding:
-1. Greet the user warmly in Korean
-2. Ask who they'd like to reconnect with
-3. Ask for a YouTube video of that person to analyze their characteristics
-4. Guide the user through the setup process
-
-Be gentle, understanding, and supportive. This is an emotional experience.
-Speak naturally in Korean unless the user prefers another language.`),
-			},
-		},
-		Tools: []*genai.Tool{
-			{
-				FunctionDeclarations: []*genai.FunctionDeclaration{
-					{
-						Name:        "generate_scene",
-						Description: "Generate a high-quality background scene image with 2-stage progressive rendering",
-						Parameters: &genai.Schema{
-							Type: genai.TypeObject,
-							Properties: map[string]*genai.Schema{
-								"prompt":     {Type: genai.TypeString, Description: "Scene description prompt"},
-								"mood":       {Type: genai.TypeString, Description: "Emotional mood (warm, nostalgic, joyful, etc.)"},
-								"characters": {Type: genai.TypeString, Description: "Character descriptions for the scene"},
-							},
-							Required: []string{"prompt", "mood"},
-						},
-					},
-					{
-						Name:        "generate_fast_scene",
-						Description: "Generate a quick preview-only scene image for rapid visual feedback",
-						Parameters: &genai.Schema{
-							Type: genai.TypeObject,
-							Properties: map[string]*genai.Schema{
-								"prompt": {Type: genai.TypeString, Description: "Scene description prompt"},
-								"mood":   {Type: genai.TypeString, Description: "Emotional mood (warm, nostalgic, joyful, etc.)"},
-							},
-							Required: []string{"prompt", "mood"},
-						},
-					},
-					{
-						Name:        "change_atmosphere",
-						Description: "Change the background music to match the conversation mood",
-						Parameters: &genai.Schema{
-							Type: genai.TypeObject,
-							Properties: map[string]*genai.Schema{
-								"mood": {Type: genai.TypeString, Description: "Target mood for BGM (warm, nostalgic, joyful, bittersweet)"},
-							},
-							Required: []string{"mood"},
-						},
-					},
-					{
-						Name:        "recall_memory",
-						Description: "Search shared memories relevant to the current conversation topic",
-						Parameters: &genai.Schema{
-							Type: genai.TypeObject,
-							Properties: map[string]*genai.Schema{
-								"query": {Type: genai.TypeString, Description: "Search query for relevant memories"},
-							},
-							Required: []string{"query"},
-						},
-					},
-					{
-						Name:        "analyze_user",
-						Description: "Analyze the user's emotional state and engagement level",
-						Parameters: &genai.Schema{
-							Type: genai.TypeObject,
-							Properties: map[string]*genai.Schema{
-								"aspect": {Type: genai.TypeString, Description: "Aspect to analyze (emotion, engagement, comfort)"},
-							},
-							Required: []string{"aspect"},
-						},
-					},
-					{
-						Name:        "end_reunion",
-						Description: "End the reunion session and generate a memory album",
-						Parameters: &genai.Schema{
-							Type: genai.TypeObject,
-							Properties: map[string]*genai.Schema{
-								"reason": {Type: genai.TypeString, Description: "Reason for ending (user_request, natural_end, timeout)"},
-							},
-							Required: []string{"reason"},
-						},
-					},
-				},
-			},
-		},
-		SessionResumption: &genai.SessionResumptionConfig{
-			Transparent: true,
-		},
-	}
 }

--- a/internal/handler/websocket_test.go
+++ b/internal/handler/websocket_test.go
@@ -3,11 +3,13 @@ package handler
 import (
 	"testing"
 
+	"github.com/Two-Weeks-Team/missless/internal/session"
 	"google.golang.org/genai"
 )
 
 func TestBuildOnboardingConfig(t *testing.T) {
-	cfg := buildOnboardingConfig()
+	mgr := session.NewManager("test-session")
+	cfg := mgr.BuildOnboardingConfig()
 
 	if cfg == nil {
 		t.Fatal("expected non-nil config")
@@ -70,7 +72,8 @@ func TestBuildOnboardingConfig(t *testing.T) {
 }
 
 func TestBuildOnboardingConfig_Modalities(t *testing.T) {
-	cfg := buildOnboardingConfig()
+	mgr := session.NewManager("test-session")
+	cfg := mgr.BuildOnboardingConfig()
 
 	hasAudio := false
 	hasText := false

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"sync"
 	"time"
+
+	"google.golang.org/genai"
 )
 
 // Manager orchestrates the session lifecycle.
@@ -14,8 +16,11 @@ type Manager struct {
 	mu    sync.Mutex
 	state State
 
-	sessionID string
-	createdAt time.Time
+	sessionID    string
+	personaName  string
+	matchedVoice string
+	languageCode string
+	createdAt    time.Time
 }
 
 // NewManager creates a new session manager.
@@ -32,6 +37,35 @@ func (m *Manager) State() State {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.state
+}
+
+// SessionID returns the session identifier.
+func (m *Manager) SessionID() string {
+	return m.sessionID
+}
+
+// SetPersona stores the matched persona details on the manager.
+func (m *Manager) SetPersona(name, voice, langCode string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.personaName = name
+	m.matchedVoice = voice
+	m.languageCode = langCode
+	slog.Info("persona_set", "session", m.sessionID, "name", name, "voice", voice)
+}
+
+// PersonaName returns the stored persona name.
+func (m *Manager) PersonaName() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.personaName
+}
+
+// MatchedVoice returns the stored matched voice.
+func (m *Manager) MatchedVoice() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.matchedVoice
 }
 
 // TransitionTo transitions to a new state with validation.
@@ -51,6 +85,116 @@ func (m *Manager) TransitionTo(target State) error {
 		"to", string(target),
 	)
 	return nil
+}
+
+// BuildOnboardingConfig creates the LiveConnectConfig for the onboarding phase.
+// System voice: Aoede (missless host), warm guide in Korean.
+func (m *Manager) BuildOnboardingConfig() *genai.LiveConnectConfig {
+	return &genai.LiveConnectConfig{
+		ResponseModalities: []genai.Modality{genai.ModalityAudio, genai.ModalityText},
+		SpeechConfig: &genai.SpeechConfig{
+			VoiceConfig: &genai.VoiceConfig{
+				PrebuiltVoiceConfig: &genai.PrebuiltVoiceConfig{
+					VoiceName: "Aoede",
+				},
+			},
+		},
+		SystemInstruction: &genai.Content{
+			Parts: []*genai.Part{
+				genai.NewPartFromText(`You are a warm, empathetic AI guide for missless - a virtual reunion experience.
+You help users reconnect with people they miss through AI-powered conversations.
+
+During onboarding:
+1. Greet the user warmly: "안녕하세요, missless에 오신 걸 환영해요"
+2. Ask who they'd like to reconnect with (name and relationship)
+3. Guide them to select YouTube videos of that person
+4. Share progress while analyzing: "영상을 분석하고 있어요, 잠시만 기다려주세요"
+5. Confirm persona creation when ready
+
+Be gentle, understanding, and supportive. This is an emotional experience.
+Speak naturally in Korean unless the user prefers another language.
+Keep responses concise for voice — avoid long monologues.`),
+			},
+		},
+		Tools: []*genai.Tool{
+			{
+				FunctionDeclarations: []*genai.FunctionDeclaration{
+					{
+						Name:        "generate_scene",
+						Description: "Generate a high-quality background scene image with 2-stage progressive rendering",
+						Parameters: &genai.Schema{
+							Type: genai.TypeObject,
+							Properties: map[string]*genai.Schema{
+								"prompt":     {Type: genai.TypeString, Description: "Scene description prompt"},
+								"mood":       {Type: genai.TypeString, Description: "Emotional mood (warm, nostalgic, joyful, etc.)"},
+								"characters": {Type: genai.TypeString, Description: "Character descriptions for the scene"},
+							},
+							Required: []string{"prompt", "mood"},
+						},
+					},
+					{
+						Name:        "generate_fast_scene",
+						Description: "Generate a quick preview-only scene image for rapid visual feedback",
+						Parameters: &genai.Schema{
+							Type: genai.TypeObject,
+							Properties: map[string]*genai.Schema{
+								"prompt": {Type: genai.TypeString, Description: "Scene description prompt"},
+								"mood":   {Type: genai.TypeString, Description: "Emotional mood (warm, nostalgic, joyful, etc.)"},
+							},
+							Required: []string{"prompt", "mood"},
+						},
+					},
+					{
+						Name:        "change_atmosphere",
+						Description: "Change the background music to match the conversation mood",
+						Parameters: &genai.Schema{
+							Type: genai.TypeObject,
+							Properties: map[string]*genai.Schema{
+								"mood": {Type: genai.TypeString, Description: "Target mood for BGM (warm, nostalgic, joyful, bittersweet)"},
+							},
+							Required: []string{"mood"},
+						},
+					},
+					{
+						Name:        "recall_memory",
+						Description: "Search shared memories relevant to the current conversation topic",
+						Parameters: &genai.Schema{
+							Type: genai.TypeObject,
+							Properties: map[string]*genai.Schema{
+								"query": {Type: genai.TypeString, Description: "Search query for relevant memories"},
+							},
+							Required: []string{"query"},
+						},
+					},
+					{
+						Name:        "analyze_user",
+						Description: "Analyze the user's emotional state and engagement level",
+						Parameters: &genai.Schema{
+							Type: genai.TypeObject,
+							Properties: map[string]*genai.Schema{
+								"aspect": {Type: genai.TypeString, Description: "Aspect to analyze (emotion, engagement, comfort)"},
+							},
+							Required: []string{"aspect"},
+						},
+					},
+					{
+						Name:        "end_reunion",
+						Description: "End the reunion session and generate a memory album",
+						Parameters: &genai.Schema{
+							Type: genai.TypeObject,
+							Properties: map[string]*genai.Schema{
+								"reason": {Type: genai.TypeString, Description: "Reason for ending (user_request, natural_end, timeout)"},
+							},
+							Required: []string{"reason"},
+						},
+					},
+				},
+			},
+		},
+		SessionResumption: &genai.SessionResumptionConfig{
+			Transparent: true,
+		},
+	}
 }
 
 // Shutdown closes all resources associated with this session.

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1,0 +1,119 @@
+package session
+
+import (
+	"strings"
+	"testing"
+
+	"google.golang.org/genai"
+)
+
+func TestManager_StartOnboarding_Config(t *testing.T) {
+	mgr := NewManager("test-session-1")
+	cfg := mgr.BuildOnboardingConfig()
+
+	if cfg == nil {
+		t.Fatal("expected non-nil LiveConnectConfig")
+	}
+
+	// Voice must be Aoede (missless host).
+	if cfg.SpeechConfig == nil || cfg.SpeechConfig.VoiceConfig == nil ||
+		cfg.SpeechConfig.VoiceConfig.PrebuiltVoiceConfig == nil {
+		t.Fatal("expected speech config with prebuilt voice")
+	}
+	if cfg.SpeechConfig.VoiceConfig.PrebuiltVoiceConfig.VoiceName != "Aoede" {
+		t.Fatalf("expected voice Aoede, got %q",
+			cfg.SpeechConfig.VoiceConfig.PrebuiltVoiceConfig.VoiceName)
+	}
+
+	// Must have Audio + Text modalities.
+	if len(cfg.ResponseModalities) != 2 {
+		t.Fatalf("expected 2 modalities, got %d", len(cfg.ResponseModalities))
+	}
+	hasAudio, hasText := false, false
+	for _, m := range cfg.ResponseModalities {
+		if m == genai.ModalityAudio {
+			hasAudio = true
+		}
+		if m == genai.ModalityText {
+			hasText = true
+		}
+	}
+	if !hasAudio || !hasText {
+		t.Fatal("expected both AUDIO and TEXT modalities")
+	}
+
+	// System instruction must mention Korean greeting.
+	if cfg.SystemInstruction == nil || len(cfg.SystemInstruction.Parts) == 0 {
+		t.Fatal("expected system instruction")
+	}
+	sysText := cfg.SystemInstruction.Parts[0].Text
+	if !strings.Contains(sysText, "missless") {
+		t.Fatalf("expected system instruction to mention 'missless', got: %s", sysText)
+	}
+	if !strings.Contains(sysText, "환영") {
+		t.Fatalf("expected Korean greeting in system instruction")
+	}
+
+	// Must have tools declared.
+	if len(cfg.Tools) == 0 {
+		t.Fatal("expected tools")
+	}
+	toolNames := make(map[string]bool)
+	for _, tool := range cfg.Tools {
+		for _, fd := range tool.FunctionDeclarations {
+			toolNames[fd.Name] = true
+		}
+	}
+	for _, name := range []string{"generate_scene", "recall_memory", "end_reunion"} {
+		if !toolNames[name] {
+			t.Fatalf("expected tool %q", name)
+		}
+	}
+
+	// Session resumption must be transparent.
+	if cfg.SessionResumption == nil || !cfg.SessionResumption.Transparent {
+		t.Fatal("expected transparent session resumption")
+	}
+}
+
+func TestManager_StateTransitions(t *testing.T) {
+	mgr := NewManager("test-session-2")
+
+	if mgr.State() != StateOnboarding {
+		t.Fatalf("expected initial state 'onboarding', got %q", mgr.State())
+	}
+
+	// Valid transition: onboarding → analyzing.
+	if err := mgr.TransitionTo(StateAnalyzing); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mgr.State() != StateAnalyzing {
+		t.Fatalf("expected state 'analyzing', got %q", mgr.State())
+	}
+
+	// Invalid transition: analyzing → reunion (should go through transitioning).
+	err := mgr.TransitionTo(StateReunion)
+	if err == nil {
+		t.Fatal("expected error for invalid transition")
+	}
+}
+
+func TestManager_SetPersona(t *testing.T) {
+	mgr := NewManager("test-session-3")
+
+	mgr.SetPersona("Mom", "Sulafat", "ko")
+
+	if mgr.PersonaName() != "Mom" {
+		t.Fatalf("expected persona 'Mom', got %q", mgr.PersonaName())
+	}
+	if mgr.MatchedVoice() != "Sulafat" {
+		t.Fatalf("expected voice 'Sulafat', got %q", mgr.MatchedVoice())
+	}
+}
+
+func TestManager_SessionID(t *testing.T) {
+	mgr := NewManager("unique-id-123")
+	if mgr.SessionID() != "unique-id-123" {
+		t.Fatalf("expected session ID 'unique-id-123', got %q", mgr.SessionID())
+	}
+}

--- a/internal/store/firestore.go
+++ b/internal/store/firestore.go
@@ -2,38 +2,108 @@ package store
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"log/slog"
+	"sync"
+	"time"
 )
 
-// FirestoreStore manages session and persona data in Cloud Firestore.
-// Lock ordering: MemoryStore.mu is Level 6 (lowest).
+// ErrSessionNotFound is returned when a session does not exist.
+var ErrSessionNotFound = errors.New("session not found")
+
+// Transcript represents a single conversation turn.
+type Transcript struct {
+	Role      string    `json:"role" firestore:"role"` // "user" | "model"
+	Text      string    `json:"text" firestore:"text"`
+	Timestamp time.Time `json:"timestamp" firestore:"timestamp"`
+}
+
+// SessionData holds the full session state persisted to Firestore.
+type SessionData struct {
+	SessionID    string            `json:"sessionId" firestore:"sessionId"`
+	PersonaName  string            `json:"personaName" firestore:"personaName"`
+	MatchedVoice string            `json:"matchedVoice" firestore:"matchedVoice"`
+	LanguageCode string            `json:"languageCode" firestore:"languageCode"`
+	OAuthToken   map[string]string `json:"oauthToken" firestore:"oauthToken"`
+	Transcripts  []Transcript      `json:"transcripts" firestore:"transcripts"`
+	ReunionCount int               `json:"reunionCount" firestore:"reunionCount"`
+	State        string            `json:"state" firestore:"state"`
+	CreatedAt    time.Time         `json:"createdAt" firestore:"createdAt"`
+	UpdatedAt    time.Time         `json:"updatedAt" firestore:"updatedAt"`
+}
+
+// FirestoreStore manages session and persona data.
+// Uses in-memory storage for hackathon; designed for Firestore migration.
+// Lock ordering: FirestoreStore.mu is Level 6 (lowest).
 type FirestoreStore struct {
+	mu        sync.RWMutex
 	projectID string
-	// TODO: T01 - Add firestore.Client field
+	sessions  map[string]*SessionData
 }
 
 // NewFirestoreStore creates a new Firestore store.
 func NewFirestoreStore(projectID string) *FirestoreStore {
-	return &FirestoreStore{projectID: projectID}
+	return &FirestoreStore{
+		projectID: projectID,
+		sessions:  make(map[string]*SessionData),
+	}
 }
 
-// SaveSession persists session state to Firestore.
-func (fs *FirestoreStore) SaveSession(ctx context.Context, sessionID string, data map[string]any) error {
-	slog.Info("firestore_save_session", "session", sessionID)
-	// TODO: T01 - Write to sessions/{sessionId}
-	return fmt.Errorf("not yet implemented")
+// SaveSession persists session state.
+func (fs *FirestoreStore) SaveSession(ctx context.Context, sessionID string, data *SessionData) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	now := time.Now()
+	data.SessionID = sessionID
+	data.UpdatedAt = now
+	if data.CreatedAt.IsZero() {
+		data.CreatedAt = now
+	}
+
+	fs.sessions[sessionID] = data
+	slog.Info("firestore_save_session", "session", sessionID, "persona", data.PersonaName)
+	return nil
 }
 
-// LoadSession retrieves session state from Firestore.
-func (fs *FirestoreStore) LoadSession(ctx context.Context, sessionID string) (map[string]any, error) {
-	slog.Info("firestore_load_session", "session", sessionID)
-	// TODO: T01 - Read from sessions/{sessionId}
-	return nil, fmt.Errorf("not yet implemented")
+// GetSession retrieves session state. Returns ErrSessionNotFound if missing.
+func (fs *FirestoreStore) GetSession(ctx context.Context, sessionID string) (*SessionData, error) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	data, ok := fs.sessions[sessionID]
+	if !ok {
+		return nil, ErrSessionNotFound
+	}
+	return data, nil
+}
+
+// SaveTranscripts appends conversation transcripts and increments reunion count.
+func (fs *FirestoreStore) SaveTranscripts(ctx context.Context, sessionID string, transcripts []Transcript, incrementReunion bool) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	data, ok := fs.sessions[sessionID]
+	if !ok {
+		return ErrSessionNotFound
+	}
+
+	data.Transcripts = append(data.Transcripts, transcripts...)
+	if incrementReunion {
+		data.ReunionCount++
+	}
+	data.UpdatedAt = time.Now()
+
+	slog.Info("firestore_save_transcripts",
+		"session", sessionID,
+		"newTranscripts", len(transcripts),
+		"totalTranscripts", len(data.Transcripts),
+		"reunionCount", data.ReunionCount,
+	)
+	return nil
 }
 
 // Flush commits any pending writes (used during graceful shutdown).
 func (fs *FirestoreStore) Flush(ctx context.Context) {
 	slog.Info("firestore_flush")
-	// TODO: Commit any pending batch writes
 }

--- a/internal/store/firestore_test.go
+++ b/internal/store/firestore_test.go
@@ -1,0 +1,130 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestFirestoreStore_SaveSession(t *testing.T) {
+	fs := NewFirestoreStore("test-project")
+	ctx := context.Background()
+
+	data := &SessionData{
+		PersonaName:  "Mom",
+		MatchedVoice: "Sulafat",
+		LanguageCode: "ko",
+		State:        "onboarding",
+		OAuthToken:   map[string]string{"access_token": "test-token"},
+	}
+
+	err := fs.SaveSession(ctx, "session-1", data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify data was stored.
+	got, err := fs.GetSession(ctx, "session-1")
+	if err != nil {
+		t.Fatalf("unexpected error on get: %v", err)
+	}
+	if got.PersonaName != "Mom" {
+		t.Fatalf("expected persona 'Mom', got %q", got.PersonaName)
+	}
+	if got.MatchedVoice != "Sulafat" {
+		t.Fatalf("expected voice 'Sulafat', got %q", got.MatchedVoice)
+	}
+	if got.SessionID != "session-1" {
+		t.Fatalf("expected sessionID 'session-1', got %q", got.SessionID)
+	}
+	if got.CreatedAt.IsZero() {
+		t.Fatal("expected non-zero CreatedAt")
+	}
+	if got.UpdatedAt.IsZero() {
+		t.Fatal("expected non-zero UpdatedAt")
+	}
+}
+
+func TestFirestoreStore_GetSession_NotFound(t *testing.T) {
+	fs := NewFirestoreStore("test-project")
+	ctx := context.Background()
+
+	_, err := fs.GetSession(ctx, "nonexistent-session")
+	if err == nil {
+		t.Fatal("expected error for nonexistent session")
+	}
+	if !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("expected ErrSessionNotFound, got: %v", err)
+	}
+}
+
+func TestFirestoreStore_SaveTranscripts(t *testing.T) {
+	fs := NewFirestoreStore("test-project")
+	ctx := context.Background()
+
+	// Create session first.
+	data := &SessionData{
+		PersonaName:  "Dad",
+		MatchedVoice: "Charon",
+		State:        "reunion",
+	}
+	if err := fs.SaveSession(ctx, "session-2", data); err != nil {
+		t.Fatalf("setup error: %v", err)
+	}
+
+	// Save transcripts with reunion increment.
+	transcripts := []Transcript{
+		{Role: "user", Text: "아빠 보고 싶어요", Timestamp: time.Now()},
+		{Role: "model", Text: "나도 보고 싶었어", Timestamp: time.Now()},
+	}
+
+	err := fs.SaveTranscripts(ctx, "session-2", transcripts, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify transcripts and reunion count.
+	got, err := fs.GetSession(ctx, "session-2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Transcripts) != 2 {
+		t.Fatalf("expected 2 transcripts, got %d", len(got.Transcripts))
+	}
+	if got.ReunionCount != 1 {
+		t.Fatalf("expected reunionCount 1, got %d", got.ReunionCount)
+	}
+
+	// Append more transcripts without reunion increment.
+	more := []Transcript{
+		{Role: "user", Text: "요즘 어떻게 지내세요?", Timestamp: time.Now()},
+	}
+	err = fs.SaveTranscripts(ctx, "session-2", more, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err = fs.GetSession(ctx, "session-2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Transcripts) != 3 {
+		t.Fatalf("expected 3 transcripts, got %d", len(got.Transcripts))
+	}
+	if got.ReunionCount != 1 {
+		t.Fatalf("expected reunionCount still 1, got %d", got.ReunionCount)
+	}
+}
+
+func TestFirestoreStore_SaveTranscripts_NotFound(t *testing.T) {
+	fs := NewFirestoreStore("test-project")
+	ctx := context.Background()
+
+	err := fs.SaveTranscripts(ctx, "nonexistent", []Transcript{
+		{Role: "user", Text: "hello"},
+	}, false)
+	if !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("expected ErrSessionNotFound, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Implement `FirestoreStore` with `SaveSession`, `GetSession`, `SaveTranscripts` (in-memory for hackathon, Firestore-ready interface)
- Add `SessionData` struct holding persona, OAuth tokens, transcripts, and reunion count
- Move `BuildOnboardingConfig` from handler to `session.Manager` (system voice: Aoede, Korean greeting)
- Add `Manager.SetPersona`, `SessionID`, `MatchedVoice` helpers for session lifecycle

## Issue
Closes #15

## Local CI
- [x] `go build ./...` passed
- [x] `go vet ./...` passed
- [x] `go test -race ./...` passed (all packages)

## Test plan
- `TestFirestoreStore_SaveSession` — save and retrieve session data
- `TestFirestoreStore_GetSession_NotFound` — returns ErrSessionNotFound
- `TestFirestoreStore_SaveTranscripts` — append transcripts + reunionCount increment
- `TestFirestoreStore_SaveTranscripts_NotFound` — error for missing session
- `TestManager_StartOnboarding_Config` — LiveConnectConfig: Aoede voice, Audio+Text modalities, Korean system instruction, tools, session resumption
- `TestManager_StateTransitions` — valid/invalid state transitions
- `TestManager_SetPersona` — persona name and voice storage
- `TestManager_SessionID` — session identifier retrieval

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 세션 저장 및 복구 기능 개선으로 사용자 경험 지속성 강화
  * 페르소나 설정(목소리, 언어) 관리 기능 추가
  * 대화 내용 저장 및 재개 지원

* **버그 수정**
  * 세션 상태 관리 로직 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->