### PR TITLE
feat(session): add onboarding→reunion transition and reunion config (#16)

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
 	"google.golang.org/genai"
 )
+
+// NotifyFunc sends a JSON event to the browser.
+type NotifyFunc func(v any)
 
 // Manager orchestrates the session lifecycle.
 // Lock ordering: Manager.mu is Level 1 (highest priority).
@@ -20,7 +24,10 @@ type Manager struct {
 	personaName  string
 	matchedVoice string
 	languageCode string
+	personality  string
+	speechStyle  string
 	createdAt    time.Time
+	notifyFn     NotifyFunc
 }
 
 // NewManager creates a new session manager.
@@ -30,6 +37,13 @@ func NewManager(sessionID string) *Manager {
 		state:     StateOnboarding,
 		createdAt: time.Now(),
 	}
+}
+
+// SetNotifyFunc sets the callback for sending events to the browser.
+func (m *Manager) SetNotifyFunc(fn NotifyFunc) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.notifyFn = fn
 }
 
 // State returns the current session state.
@@ -45,12 +59,14 @@ func (m *Manager) SessionID() string {
 }
 
 // SetPersona stores the matched persona details on the manager.
-func (m *Manager) SetPersona(name, voice, langCode string) {
+func (m *Manager) SetPersona(name, voice, langCode, personality, speechStyle string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.personaName = name
 	m.matchedVoice = voice
 	m.languageCode = langCode
+	m.personality = personality
+	m.speechStyle = speechStyle
 	slog.Info("persona_set", "session", m.sessionID, "name", name, "voice", voice)
 }
 
@@ -87,6 +103,43 @@ func (m *Manager) TransitionTo(target State) error {
 	return nil
 }
 
+// TransitionToReunion orchestrates the full onboarding→reunion transition.
+// Steps: analyzing → transitioning (notify browser) → reunion (swap session).
+func (m *Manager) TransitionToReunion(ctx context.Context) error {
+	// State: onboarding → analyzing (video analysis started).
+	if err := m.TransitionTo(StateAnalyzing); err != nil {
+		return fmt.Errorf("transition to analyzing: %w", err)
+	}
+
+	// State: analyzing → transitioning.
+	if err := m.TransitionTo(StateTransitioning); err != nil {
+		return fmt.Errorf("transition to transitioning: %w", err)
+	}
+
+	// Notify browser: "잠시 눈을 감아보세요..."
+	m.notify(map[string]any{
+		"type":    "session_transition",
+		"message": "잠시 눈을 감아보세요...",
+		"persona": m.PersonaName(),
+		"voice":   m.MatchedVoice(),
+	})
+
+	// State: transitioning → reunion.
+	if err := m.TransitionTo(StateReunion); err != nil {
+		return fmt.Errorf("transition to reunion: %w", err)
+	}
+
+	// Notify browser: session ready.
+	m.notify(map[string]any{
+		"type":    "session_ready",
+		"state":   "reunion",
+		"persona": m.PersonaName(),
+		"voice":   m.MatchedVoice(),
+	})
+
+	return nil
+}
+
 // BuildOnboardingConfig creates the LiveConnectConfig for the onboarding phase.
 // System voice: Aoede (missless host), warm guide in Korean.
 func (m *Manager) BuildOnboardingConfig() *genai.LiveConnectConfig {
@@ -118,82 +171,88 @@ Keep responses concise for voice — avoid long monologues.`),
 		},
 		Tools: []*genai.Tool{
 			{
-				FunctionDeclarations: []*genai.FunctionDeclaration{
-					{
-						Name:        "generate_scene",
-						Description: "Generate a high-quality background scene image with 2-stage progressive rendering",
-						Parameters: &genai.Schema{
-							Type: genai.TypeObject,
-							Properties: map[string]*genai.Schema{
-								"prompt":     {Type: genai.TypeString, Description: "Scene description prompt"},
-								"mood":       {Type: genai.TypeString, Description: "Emotional mood (warm, nostalgic, joyful, etc.)"},
-								"characters": {Type: genai.TypeString, Description: "Character descriptions for the scene"},
-							},
-							Required: []string{"prompt", "mood"},
-						},
-					},
-					{
-						Name:        "generate_fast_scene",
-						Description: "Generate a quick preview-only scene image for rapid visual feedback",
-						Parameters: &genai.Schema{
-							Type: genai.TypeObject,
-							Properties: map[string]*genai.Schema{
-								"prompt": {Type: genai.TypeString, Description: "Scene description prompt"},
-								"mood":   {Type: genai.TypeString, Description: "Emotional mood (warm, nostalgic, joyful, etc.)"},
-							},
-							Required: []string{"prompt", "mood"},
-						},
-					},
-					{
-						Name:        "change_atmosphere",
-						Description: "Change the background music to match the conversation mood",
-						Parameters: &genai.Schema{
-							Type: genai.TypeObject,
-							Properties: map[string]*genai.Schema{
-								"mood": {Type: genai.TypeString, Description: "Target mood for BGM (warm, nostalgic, joyful, bittersweet)"},
-							},
-							Required: []string{"mood"},
-						},
-					},
-					{
-						Name:        "recall_memory",
-						Description: "Search shared memories relevant to the current conversation topic",
-						Parameters: &genai.Schema{
-							Type: genai.TypeObject,
-							Properties: map[string]*genai.Schema{
-								"query": {Type: genai.TypeString, Description: "Search query for relevant memories"},
-							},
-							Required: []string{"query"},
-						},
-					},
-					{
-						Name:        "analyze_user",
-						Description: "Analyze the user's emotional state and engagement level",
-						Parameters: &genai.Schema{
-							Type: genai.TypeObject,
-							Properties: map[string]*genai.Schema{
-								"aspect": {Type: genai.TypeString, Description: "Aspect to analyze (emotion, engagement, comfort)"},
-							},
-							Required: []string{"aspect"},
-						},
-					},
-					{
-						Name:        "end_reunion",
-						Description: "End the reunion session and generate a memory album",
-						Parameters: &genai.Schema{
-							Type: genai.TypeObject,
-							Properties: map[string]*genai.Schema{
-								"reason": {Type: genai.TypeString, Description: "Reason for ending (user_request, natural_end, timeout)"},
-							},
-							Required: []string{"reason"},
-						},
-					},
-				},
+				FunctionDeclarations: onboardingTools(),
 			},
 		},
 		SessionResumption: &genai.SessionResumptionConfig{
 			Transparent: true,
 		},
+	}
+}
+
+// BuildReunionConfig creates the LiveConnectConfig for the reunion phase.
+// Uses the persona's matched HD voice and personality as system instruction.
+func (m *Manager) BuildReunionConfig() *genai.LiveConnectConfig {
+	m.mu.Lock()
+	voice := m.matchedVoice
+	name := m.personaName
+	personality := m.personality
+	speechStyle := m.speechStyle
+	lang := m.languageCode
+	m.mu.Unlock()
+
+	if voice == "" {
+		voice = "Aoede" // fallback
+	}
+
+	sysInstruction := buildReunionSystemInstruction(name, personality, speechStyle, lang)
+
+	return &genai.LiveConnectConfig{
+		ResponseModalities: []genai.Modality{genai.ModalityAudio, genai.ModalityText},
+		SpeechConfig: &genai.SpeechConfig{
+			VoiceConfig: &genai.VoiceConfig{
+				PrebuiltVoiceConfig: &genai.PrebuiltVoiceConfig{
+					VoiceName: voice,
+				},
+			},
+		},
+		SystemInstruction: &genai.Content{
+			Parts: []*genai.Part{
+				genai.NewPartFromText(sysInstruction),
+			},
+		},
+		Tools: []*genai.Tool{
+			{
+				FunctionDeclarations: reunionTools(),
+			},
+		},
+		SessionResumption: &genai.SessionResumptionConfig{
+			Transparent: true,
+		},
+	}
+}
+
+// BuildOnboardingSummary creates a summary of the onboarding conversation
+// to inject as client content into the reunion session.
+func (m *Manager) BuildOnboardingSummary() string {
+	m.mu.Lock()
+	name := m.personaName
+	voice := m.matchedVoice
+	personality := m.personality
+	speechStyle := m.speechStyle
+	lang := m.languageCode
+	m.mu.Unlock()
+
+	var sb strings.Builder
+	sb.WriteString("=== Onboarding Summary ===\n")
+	sb.WriteString(fmt.Sprintf("Persona: %s\n", name))
+	sb.WriteString(fmt.Sprintf("Matched Voice: %s\n", voice))
+	sb.WriteString(fmt.Sprintf("Personality: %s\n", personality))
+	sb.WriteString(fmt.Sprintf("Speech Style: %s\n", speechStyle))
+	sb.WriteString(fmt.Sprintf("Language: %s\n", lang))
+	sb.WriteString("The user has just completed onboarding and is about to experience a reunion.\n")
+	sb.WriteString("Begin the reunion naturally, as if meeting after a long time.\n")
+	return sb.String()
+}
+
+// notify sends an event to the browser if the notify function is set.
+func (m *Manager) notify(v any) {
+	m.mu.Lock()
+	fn := m.notifyFn
+	m.mu.Unlock()
+
+	if fn != nil {
+		fn(v)
 	}
 }
 
@@ -203,4 +262,174 @@ func (m *Manager) Shutdown(ctx context.Context) {
 	defer m.mu.Unlock()
 	m.state = StateEnded
 	slog.Info("session_shutdown", "session", m.sessionID)
+}
+
+func buildReunionSystemInstruction(name, personality, speechStyle, lang string) string {
+	langNote := "Speak naturally in Korean."
+	if lang != "" && lang != "ko" {
+		langNote = fmt.Sprintf("Speak naturally in the language code '%s'.", lang)
+	}
+
+	return fmt.Sprintf(`You are %s. You are having a reunion with someone who misses you deeply.
+
+Personality: %s
+Speech style: %s
+
+Guidelines:
+1. Stay completely in character as %s — never break character
+2. Greet warmly as if meeting after a long time apart
+3. Reference shared memories and experiences naturally
+4. Show genuine emotion and warmth
+5. %s
+6. Keep responses natural and conversational for voice
+7. React to the user's emotions with empathy and understanding
+8. Use characteristic phrases and speech patterns`, name, personality, speechStyle, name, langNote)
+}
+
+func onboardingTools() []*genai.FunctionDeclaration {
+	return []*genai.FunctionDeclaration{
+		{
+			Name:        "generate_scene",
+			Description: "Generate a high-quality background scene image with 2-stage progressive rendering",
+			Parameters: &genai.Schema{
+				Type: genai.TypeObject,
+				Properties: map[string]*genai.Schema{
+					"prompt":     {Type: genai.TypeString, Description: "Scene description prompt"},
+					"mood":       {Type: genai.TypeString, Description: "Emotional mood (warm, nostalgic, joyful, etc.)"},
+					"characters": {Type: genai.TypeString, Description: "Character descriptions for the scene"},
+				},
+				Required: []string{"prompt", "mood"},
+			},
+		},
+		{
+			Name:        "generate_fast_scene",
+			Description: "Generate a quick preview-only scene image for rapid visual feedback",
+			Parameters: &genai.Schema{
+				Type: genai.TypeObject,
+				Properties: map[string]*genai.Schema{
+					"prompt": {Type: genai.TypeString, Description: "Scene description prompt"},
+					"mood":   {Type: genai.TypeString, Description: "Emotional mood (warm, nostalgic, joyful, etc.)"},
+				},
+				Required: []string{"prompt", "mood"},
+			},
+		},
+		{
+			Name:        "change_atmosphere",
+			Description: "Change the background music to match the conversation mood",
+			Parameters: &genai.Schema{
+				Type: genai.TypeObject,
+				Properties: map[string]*genai.Schema{
+					"mood": {Type: genai.TypeString, Description: "Target mood for BGM (warm, nostalgic, joyful, bittersweet)"},
+				},
+				Required: []string{"mood"},
+			},
+		},
+		{
+			Name:        "recall_memory",
+			Description: "Search shared memories relevant to the current conversation topic",
+			Parameters: &genai.Schema{
+				Type: genai.TypeObject,
+				Properties: map[string]*genai.Schema{
+					"query": {Type: genai.TypeString, Description: "Search query for relevant memories"},
+				},
+				Required: []string{"query"},
+			},
+		},
+		{
+			Name:        "analyze_user",
+			Description: "Analyze the user's emotional state and engagement level",
+			Parameters: &genai.Schema{
+				Type: genai.TypeObject,
+				Properties: map[string]*genai.Schema{
+					"aspect": {Type: genai.TypeString, Description: "Aspect to analyze (emotion, engagement, comfort)"},
+				},
+				Required: []string{"aspect"},
+			},
+		},
+		{
+			Name:        "end_reunion",
+			Description: "End the reunion session and generate a memory album",
+			Parameters: &genai.Schema{
+				Type: genai.TypeObject,
+				Properties: map[string]*genai.Schema{
+					"reason": {Type: genai.TypeString, Description: "Reason for ending (user_request, natural_end, timeout)"},
+				},
+				Required: []string{"reason"},
+			},
+		},
+	}
+}
+
+func reunionTools() []*genai.FunctionDeclaration {
+	return []*genai.FunctionDeclaration{
+		{
+			Name:        "generate_scene",
+			Description: "Generate a background scene based on the conversation topic",
+			Parameters: &genai.Schema{
+				Type: genai.TypeObject,
+				Properties: map[string]*genai.Schema{
+					"prompt":     {Type: genai.TypeString, Description: "Scene description prompt"},
+					"mood":       {Type: genai.TypeString, Description: "Emotional mood"},
+					"characters": {Type: genai.TypeString, Description: "Character descriptions"},
+				},
+				Required: []string{"prompt", "mood"},
+			},
+		},
+		{
+			Name:        "generate_fast_scene",
+			Description: "Quick preview scene for rapid visual feedback",
+			Parameters: &genai.Schema{
+				Type: genai.TypeObject,
+				Properties: map[string]*genai.Schema{
+					"prompt": {Type: genai.TypeString, Description: "Scene description prompt"},
+					"mood":   {Type: genai.TypeString, Description: "Emotional mood"},
+				},
+				Required: []string{"prompt", "mood"},
+			},
+		},
+		{
+			Name:        "change_atmosphere",
+			Description: "Change background music mood",
+			Parameters: &genai.Schema{
+				Type: genai.TypeObject,
+				Properties: map[string]*genai.Schema{
+					"mood": {Type: genai.TypeString, Description: "Target mood for BGM"},
+				},
+				Required: []string{"mood"},
+			},
+		},
+		{
+			Name:        "recall_memory",
+			Description: "Search shared memories from the past",
+			Parameters: &genai.Schema{
+				Type: genai.TypeObject,
+				Properties: map[string]*genai.Schema{
+					"query": {Type: genai.TypeString, Description: "Memory search query"},
+				},
+				Required: []string{"query"},
+			},
+		},
+		{
+			Name:        "analyze_user",
+			Description: "Analyze the user's emotional state",
+			Parameters: &genai.Schema{
+				Type: genai.TypeObject,
+				Properties: map[string]*genai.Schema{
+					"aspect": {Type: genai.TypeString, Description: "Aspect to analyze"},
+				},
+				Required: []string{"aspect"},
+			},
+		},
+		{
+			Name:        "end_reunion",
+			Description: "End the reunion and generate a memory album",
+			Parameters: &genai.Schema{
+				Type: genai.TypeObject,
+				Properties: map[string]*genai.Schema{
+					"reason": {Type: genai.TypeString, Description: "Reason for ending"},
+				},
+				Required: []string{"reason"},
+			},
+		},
+	}
 }

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1,7 +1,9 @@
 package session
 
 import (
+	"context"
 	"strings"
+	"sync"
 	"testing"
 
 	"google.golang.org/genai"
@@ -76,6 +78,112 @@ func TestManager_StartOnboarding_Config(t *testing.T) {
 	}
 }
 
+func TestManager_Transition_StateChange(t *testing.T) {
+	mgr := NewManager("test-transition")
+
+	if mgr.State() != StateOnboarding {
+		t.Fatalf("expected initial state 'onboarding', got %q", mgr.State())
+	}
+
+	// Set persona before transition.
+	mgr.SetPersona("Mom", "Sulafat", "ko", "Warm and caring", "Gentle with rising intonation")
+
+	// Execute full transition.
+	err := mgr.TransitionToReunion(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if mgr.State() != StateReunion {
+		t.Fatalf("expected state 'reunion', got %q", mgr.State())
+	}
+}
+
+func TestManager_Transition_NotifyBrowser(t *testing.T) {
+	mgr := NewManager("test-notify")
+	mgr.SetPersona("Mom", "Sulafat", "ko", "Warm", "Gentle")
+
+	var mu sync.Mutex
+	var events []map[string]any
+
+	mgr.SetNotifyFunc(func(v any) {
+		mu.Lock()
+		defer mu.Unlock()
+		if m, ok := v.(map[string]any); ok {
+			events = append(events, m)
+		}
+	})
+
+	err := mgr.TransitionToReunion(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events (session_transition + session_ready), got %d", len(events))
+	}
+
+	// First: session_transition with "눈 감아보세요".
+	if events[0]["type"] != "session_transition" {
+		t.Fatalf("expected type 'session_transition', got %q", events[0]["type"])
+	}
+	msg, _ := events[0]["message"].(string)
+	if !strings.Contains(msg, "눈을 감아보세요") {
+		t.Fatalf("expected '눈을 감아보세요' in message, got %q", msg)
+	}
+
+	// Second: session_ready.
+	if events[1]["type"] != "session_ready" {
+		t.Fatalf("expected type 'session_ready', got %q", events[1]["type"])
+	}
+	if events[1]["state"] != "reunion" {
+		t.Fatalf("expected state 'reunion', got %q", events[1]["state"])
+	}
+}
+
+func TestManager_BuildReunionConfig(t *testing.T) {
+	mgr := NewManager("test-reunion-cfg")
+	mgr.SetPersona("Mom", "Sulafat", "ko", "Warm and caring", "Gentle with rising intonation")
+
+	cfg := mgr.BuildReunionConfig()
+
+	// Voice must be the persona's matched voice.
+	if cfg.SpeechConfig.VoiceConfig.PrebuiltVoiceConfig.VoiceName != "Sulafat" {
+		t.Fatalf("expected voice 'Sulafat', got %q",
+			cfg.SpeechConfig.VoiceConfig.PrebuiltVoiceConfig.VoiceName)
+	}
+
+	// System instruction must contain the persona name.
+	sysText := cfg.SystemInstruction.Parts[0].Text
+	if !strings.Contains(sysText, "Mom") {
+		t.Fatalf("expected persona name 'Mom' in system instruction")
+	}
+	if !strings.Contains(sysText, "Warm and caring") {
+		t.Fatalf("expected personality in system instruction")
+	}
+
+	// Must have tools.
+	if len(cfg.Tools) == 0 || len(cfg.Tools[0].FunctionDeclarations) == 0 {
+		t.Fatal("expected reunion tools")
+	}
+}
+
+func TestBuildOnboardingSummary(t *testing.T) {
+	mgr := NewManager("test-summary")
+	mgr.SetPersona("Mom", "Sulafat", "ko", "Warm and caring", "Gentle")
+
+	summary := mgr.BuildOnboardingSummary()
+
+	for _, expected := range []string{"Mom", "Sulafat", "Warm and caring", "ko"} {
+		if !strings.Contains(summary, expected) {
+			t.Fatalf("expected summary to contain %q, got: %s", expected, summary)
+		}
+	}
+}
+
 func TestManager_StateTransitions(t *testing.T) {
 	mgr := NewManager("test-session-2")
 
@@ -101,7 +209,7 @@ func TestManager_StateTransitions(t *testing.T) {
 func TestManager_SetPersona(t *testing.T) {
 	mgr := NewManager("test-session-3")
 
-	mgr.SetPersona("Mom", "Sulafat", "ko")
+	mgr.SetPersona("Mom", "Sulafat", "ko", "Warm", "Gentle")
 
 	if mgr.PersonaName() != "Mom" {
 		t.Fatalf("expected persona 'Mom', got %q", mgr.PersonaName())


### PR DESCRIPTION
## Summary
- Add `TransitionToReunion` orchestrating state machine: onboarding→analyzing→transitioning→reunion
- Add `BuildReunionConfig` using persona's matched HD voice and personality as system instruction
- Add `BuildOnboardingSummary` for client content injection into reunion session
- Add `NotifyFunc` for browser events: `session_transition` ("눈 감아보세요") and `session_ready`
- Refactor tools into `onboardingTools()` and `reunionTools()` helper functions

## Issue
Closes #16

## Local CI
- [x] `go build ./...` passed
- [x] `go vet ./...` passed
- [x] `go test -race ./...` passed (all packages)

## Test plan
- `TestManager_Transition_StateChange` — Full onboarding→reunion state transition
- `TestManager_Transition_NotifyBrowser` — Verifies session_transition + session_ready events
- `TestManager_BuildReunionConfig` — Persona voice, system instruction, tools validation
- `TestBuildOnboardingSummary` — Persona info (name, voice, personality, language) included
- Existing proxy SwapSession tests cover session swap behavior