### PR TITLE
feat(web): add onboarding UX with progress, highlights, and video grid (#17)

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -29,3 +29,14 @@ body {
     transform: rotate(360deg);
   }
 }
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateX(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -5,6 +5,9 @@ import { useWebSocket, ServerMessage } from '../hooks/useWebSocket';
 import { useAudio } from '../hooks/useAudio';
 import SceneDisplay from '../components/SceneDisplay';
 import SessionTransition from '../components/SessionTransition';
+import OnboardingFlow, { type OnboardingStage } from '../components/OnboardingFlow';
+import type { YouTubeVideo } from '../components/YouTubeGrid';
+import type { Highlight } from '../components/HighlightCard';
 
 type TransitionPhase = 'idle' | 'transitioning' | 'ready';
 
@@ -23,6 +26,14 @@ export default function Home() {
   const [transcript, setTranscript] = useState<string>('');
   const readyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Onboarding state
+  const [onboardingStage, setOnboardingStage] = useState<OnboardingStage>('welcome');
+  const [videos, setVideos] = useState<YouTubeVideo[]>([]);
+  const [personCrops, setPersonCrops] = useState<string[]>([]);
+  const [highlights, setHighlights] = useState<Highlight[]>([]);
+  const [analysisStep, setAnalysisStep] = useState('');
+  const [analysisPercent, setAnalysisPercent] = useState(0);
+
   const { initAudioContext, playPCM, cleanup: cleanupAudio } = useAudio();
 
   const handleMessage = useCallback((msg: ServerMessage) => {
@@ -38,12 +49,39 @@ export default function Home() {
         break;
       case 'session_transition':
         setTransition('transitioning');
+        setOnboardingStage('transition');
         break;
       case 'session_ready':
         setTransition('ready');
+        setOnboardingStage('reunion');
         break;
       case 'transcript':
         setTranscript(msg.text);
+        break;
+      case 'youtube_videos':
+        setVideos(msg.videos as YouTubeVideo[]);
+        setOnboardingStage('youtube_grid');
+        break;
+      case 'person_detected':
+        setPersonCrops(msg.crops);
+        setOnboardingStage('person_select');
+        break;
+      case 'analysis_progress':
+        setOnboardingStage('analyzing');
+        setAnalysisStep(msg.step);
+        setAnalysisPercent(msg.percent);
+        if (msg.highlight) {
+          try {
+            const h = JSON.parse(msg.highlight) as Highlight;
+            setHighlights((prev) => [...prev, h]);
+          } catch {
+            // Highlight may be a plain string description
+            setHighlights((prev) => [
+              ...prev,
+              { timestamp: '', description: msg.highlight as string, expression: '' },
+            ]);
+          }
+        }
         break;
     }
   }, [playPCM]);
@@ -65,7 +103,7 @@ export default function Home() {
     ? `ws://${window.location.hostname}:${window.location.port || '18080'}/ws`
     : '';
 
-  const { state, connect, disconnect } = useWebSocket(wsUrl, handleMessage);
+  const { state, connect, send, disconnect } = useWebSocket(wsUrl, handleMessage);
 
   const handleStart = () => {
     initAudioContext();
@@ -81,7 +119,23 @@ export default function Home() {
     setFinalSrc(null);
     setTransition('idle');
     setTranscript('');
+    setOnboardingStage('welcome');
+    setVideos([]);
+    setPersonCrops([]);
+    setHighlights([]);
+    setAnalysisStep('');
+    setAnalysisPercent(0);
   };
+
+  const handleSelectVideo = useCallback((videoId: string) => {
+    send({ type: 'select_video', videoId });
+    setOnboardingStage('analyzing');
+  }, [send]);
+
+  const handleSelectPerson = useCallback((personIndex: number) => {
+    send({ type: 'select_person', personIndex });
+    setOnboardingStage('analyzing');
+  }, [send]);
 
   if (!started) {
     return (
@@ -123,6 +177,16 @@ export default function Home() {
     <main style={{ position: 'relative', height: '100dvh', width: '100dvw' }}>
       <SceneDisplay previewSrc={previewSrc} finalSrc={finalSrc} />
       <SessionTransition phase={transition} />
+      <OnboardingFlow
+        stage={onboardingStage}
+        videos={videos}
+        personCrops={personCrops}
+        highlights={highlights}
+        analysisStep={analysisStep}
+        analysisPercent={analysisPercent}
+        onSelectVideo={handleSelectVideo}
+        onSelectPerson={handleSelectPerson}
+      />
 
       {/* Connection indicator */}
       <div

--- a/web/components/HighlightCard.tsx
+++ b/web/components/HighlightCard.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+export interface Highlight {
+  timestamp: string;
+  description: string;
+  expression: string;
+}
+
+interface HighlightCardProps {
+  highlights: Highlight[];
+}
+
+export default function HighlightCard({ highlights }: HighlightCardProps) {
+  if (highlights.length === 0) return null;
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: '4rem',
+        right: '1rem',
+        maxHeight: '60vh',
+        overflowY: 'auto',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.5rem',
+        zIndex: 20,
+        width: '280px',
+      }}
+    >
+      {highlights.map((h, i) => (
+        <div
+          key={`${h.timestamp}-${i}`}
+          style={{
+            padding: '0.75rem 1rem',
+            background: 'rgba(0,0,0,0.6)',
+            backdropFilter: 'blur(8px)',
+            borderRadius: '0.75rem',
+            borderLeft: '3px solid var(--color-primary)',
+            animation: 'slideIn 0.3s ease-out',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              marginBottom: '0.25rem',
+            }}
+          >
+            <span style={{ fontSize: '0.75rem', color: 'var(--color-primary)' }}>
+              {h.timestamp}
+            </span>
+            <span style={{ fontSize: '0.75rem', color: 'var(--color-muted)' }}>
+              {h.expression}
+            </span>
+          </div>
+          <p style={{ fontSize: '0.875rem', color: 'var(--color-text)', margin: 0 }}>
+            {h.description}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/components/OnboardingFlow.tsx
+++ b/web/components/OnboardingFlow.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import ProgressBar from './ProgressBar';
+import HighlightCard, { type Highlight } from './HighlightCard';
+import YouTubeGrid, { type YouTubeVideo } from './YouTubeGrid';
+import PrivateVideoPopup from './PrivateVideoPopup';
+
+export type OnboardingStage =
+  | 'welcome'
+  | 'youtube_grid'
+  | 'person_select'
+  | 'analyzing'
+  | 'transition'
+  | 'reunion';
+
+interface OnboardingFlowProps {
+  stage: OnboardingStage;
+  videos: YouTubeVideo[];
+  personCrops: string[];
+  highlights: Highlight[];
+  analysisStep: string;
+  analysisPercent: number;
+  onSelectVideo: (videoId: string) => void;
+  onSelectPerson: (index: number) => void;
+}
+
+export default function OnboardingFlow({
+  stage,
+  videos,
+  personCrops,
+  highlights,
+  analysisStep,
+  analysisPercent,
+  onSelectVideo,
+  onSelectPerson,
+}: OnboardingFlowProps) {
+  const [showPrivatePopup, setShowPrivatePopup] = useState(false);
+
+  const handlePrivateClick = useCallback(() => {
+    setShowPrivatePopup(true);
+  }, []);
+
+  return (
+    <>
+      {/* YouTube video selection grid */}
+      {stage === 'youtube_grid' && (
+        <YouTubeGrid
+          videos={videos}
+          onSelect={onSelectVideo}
+          onPrivateClick={handlePrivateClick}
+        />
+      )}
+
+      {/* Person crop selection grid */}
+      {stage === 'person_select' && personCrops.length > 0 && (
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            background: 'var(--color-bg)',
+            zIndex: 30,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '2rem',
+          }}
+        >
+          <h2
+            style={{
+              fontSize: '1.25rem',
+              marginBottom: '1.5rem',
+              color: 'var(--color-text)',
+            }}
+          >
+            분석할 인물을 선택하세요
+          </h2>
+          <div
+            style={{
+              display: 'flex',
+              gap: '1rem',
+              flexWrap: 'wrap',
+              justifyContent: 'center',
+            }}
+          >
+            {personCrops.map((crop, i) => (
+              <button
+                key={i}
+                onClick={() => onSelectPerson(i)}
+                style={{
+                  width: 100,
+                  height: 100,
+                  borderRadius: '50%',
+                  overflow: 'hidden',
+                  border: '3px solid transparent',
+                  cursor: 'pointer',
+                  padding: 0,
+                  background: 'var(--color-surface)',
+                  transition: 'border-color 0.2s',
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.borderColor = 'var(--color-primary)';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.borderColor = 'transparent';
+                }}
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={crop}
+                  alt={`Person ${i + 1}`}
+                  style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                />
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Analysis progress and highlights */}
+      {stage === 'analyzing' && (
+        <>
+          <ProgressBar step={analysisStep} percent={analysisPercent} />
+          <HighlightCard highlights={highlights} />
+        </>
+      )}
+
+      {/* Private video popup */}
+      {showPrivatePopup && (
+        <PrivateVideoPopup onClose={() => setShowPrivatePopup(false)} />
+      )}
+    </>
+  );
+}

--- a/web/components/PrivateVideoPopup.tsx
+++ b/web/components/PrivateVideoPopup.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+interface PrivateVideoPopupProps {
+  onClose: () => void;
+}
+
+export default function PrivateVideoPopup({ onClose }: PrivateVideoPopupProps) {
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'rgba(0,0,0,0.7)',
+        zIndex: 40,
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          background: 'var(--color-surface)',
+          borderRadius: '1rem',
+          padding: '2rem',
+          maxWidth: '320px',
+          textAlign: 'center',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <p style={{ fontSize: '1rem', color: 'var(--color-text)', marginBottom: '0.5rem' }}>
+          비공개 영상입니다
+        </p>
+        <p style={{ fontSize: '0.875rem', color: 'var(--color-muted)', marginBottom: '1.5rem' }}>
+          비공개 또는 미등록 영상은 직접 분석할 수 없어요.
+          공개 영상을 선택하거나, 영상을 직접 업로드해주세요.
+        </p>
+        <button
+          onClick={onClose}
+          style={{
+            padding: '0.5rem 2rem',
+            background: 'var(--color-primary)',
+            color: 'white',
+            border: 'none',
+            borderRadius: '2rem',
+            cursor: 'pointer',
+            fontSize: '0.875rem',
+          }}
+        >
+          확인
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/components/ProgressBar.tsx
+++ b/web/components/ProgressBar.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+interface ProgressBarProps {
+  step: string;
+  percent: number;
+}
+
+export default function ProgressBar({ step, percent }: ProgressBarProps) {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        bottom: '8rem',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        width: '80%',
+        maxWidth: '400px',
+        zIndex: 20,
+      }}
+    >
+      <p
+        style={{
+          fontSize: '0.875rem',
+          color: 'var(--color-muted)',
+          marginBottom: '0.5rem',
+          textAlign: 'center',
+        }}
+      >
+        {step}
+      </p>
+      <div
+        style={{
+          width: '100%',
+          height: 6,
+          background: 'rgba(255,255,255,0.1)',
+          borderRadius: 3,
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{
+            width: `${Math.min(100, Math.max(0, percent))}%`,
+            height: '100%',
+            background: 'var(--color-primary)',
+            borderRadius: 3,
+            transition: 'width 0.4s ease-out',
+          }}
+        />
+      </div>
+      <p
+        style={{
+          fontSize: '0.75rem',
+          color: 'var(--color-muted)',
+          marginTop: '0.25rem',
+          textAlign: 'right',
+        }}
+      >
+        {percent}%
+      </p>
+    </div>
+  );
+}

--- a/web/components/YouTubeGrid.tsx
+++ b/web/components/YouTubeGrid.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+export interface YouTubeVideo {
+  id: string;
+  title: string;
+  thumbnail: string;
+  privacyStatus: string;
+}
+
+interface YouTubeGridProps {
+  videos: YouTubeVideo[];
+  onSelect: (videoId: string) => void;
+  onPrivateClick: () => void;
+}
+
+export default function YouTubeGrid({ videos, onSelect, onPrivateClick }: YouTubeGridProps) {
+  if (videos.length === 0) return null;
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        background: 'var(--color-bg)',
+        zIndex: 30,
+        overflowY: 'auto',
+        padding: '1rem',
+      }}
+    >
+      <h2
+        style={{
+          fontSize: '1.25rem',
+          marginBottom: '1rem',
+          textAlign: 'center',
+          color: 'var(--color-text)',
+        }}
+      >
+        영상을 선택하세요
+      </h2>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))',
+          gap: '0.75rem',
+          maxWidth: '600px',
+          margin: '0 auto',
+        }}
+      >
+        {videos.map((video) => {
+          const isPrivate = video.privacyStatus !== 'public';
+          return (
+            <button
+              key={video.id}
+              onClick={() => isPrivate ? onPrivateClick() : onSelect(video.id)}
+              style={{
+                position: 'relative',
+                background: 'var(--color-surface)',
+                border: 'none',
+                borderRadius: '0.75rem',
+                overflow: 'hidden',
+                cursor: 'pointer',
+                padding: 0,
+                opacity: isPrivate ? 0.5 : 1,
+                transition: 'transform 0.2s',
+              }}
+              onMouseEnter={(e) => {
+                if (!isPrivate) e.currentTarget.style.transform = 'scale(1.03)';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.transform = 'scale(1)';
+              }}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={video.thumbnail}
+                alt={video.title}
+                style={{
+                  width: '100%',
+                  aspectRatio: '16/9',
+                  objectFit: 'cover',
+                  display: 'block',
+                }}
+              />
+              <div style={{ padding: '0.5rem' }}>
+                <p
+                  style={{
+                    fontSize: '0.75rem',
+                    color: 'var(--color-text)',
+                    margin: 0,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {video.title}
+                </p>
+              </div>
+              {isPrivate && (
+                <div
+                  style={{
+                    position: 'absolute',
+                    top: '0.25rem',
+                    right: '0.25rem',
+                    background: 'rgba(0,0,0,0.7)',
+                    color: 'var(--color-muted)',
+                    fontSize: '0.625rem',
+                    padding: '0.125rem 0.375rem',
+                    borderRadius: '0.25rem',
+                  }}
+                >
+                  비공개
+                </div>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `OnboardingFlow` state machine component: welcome → youtube_grid → person_select → analyzing → transition → reunion
- Add `YouTubeGrid` for video selection with privacy status indicators and touch support
- Add `ProgressBar` for real-time analysis progress (0-100%) with step labels
- Add `HighlightCard` for real-time display of video analysis highlights
- Add `PrivateVideoPopup` guiding users to select public videos or upload directly
- Integrate all components into `page.tsx` with WebSocket message handling

## Issue
Closes #17

## Local CI
- [x] `npx tsc --noEmit` passed (type check)
- [x] `npm run build` passed (Next.js static export)
- [x] `go test -race ./...` passed (backend unchanged)

## Test plan
- UI state transitions verified via WebSocket message types
- `youtube_videos` message → shows video grid
- `person_detected` message → shows person crop selection
- `analysis_progress` message → shows progress bar + highlight cards
- Private video tap → popup with guidance
- `session_transition` / `session_ready` → transition overlay