### PR TITLE
feat: BGM preset system with crossfade (#20)

### DIFF
--- a/internal/live/bgm.go
+++ b/internal/live/bgm.go
@@ -1,0 +1,39 @@
+package live
+
+// BGMPreset defines a mood-to-BGM URL mapping.
+type BGMPreset struct {
+	Mood string `json:"mood"`
+	URL  string `json:"url"`
+}
+
+// presetBGMs maps mood keywords to BGM URLs.
+// Local fallback paths serve from web/public/bgm/.
+var presetBGMs = map[string]BGMPreset{
+	"warm":      {Mood: "warm", URL: "/bgm/warm.mp3"},
+	"romantic":  {Mood: "romantic", URL: "/bgm/romantic.mp3"},
+	"nostalgic": {Mood: "nostalgic", URL: "/bgm/nostalgic.mp3"},
+	"playful":   {Mood: "playful", URL: "/bgm/playful.mp3"},
+	"emotional": {Mood: "emotional", URL: "/bgm/emotional.mp3"},
+	"farewell":  {Mood: "farewell", URL: "/bgm/farewell.mp3"},
+}
+
+// defaultMood is used when the requested mood doesn't match any preset.
+const defaultMood = "nostalgic"
+
+// GetPresetBGMURL returns the BGM URL for a mood.
+// Falls back to "nostalgic" for unknown moods.
+func GetPresetBGMURL(mood string) BGMPreset {
+	if p, ok := presetBGMs[mood]; ok {
+		return p
+	}
+	return presetBGMs[defaultMood]
+}
+
+// AllPresetMoods returns all available BGM mood names.
+func AllPresetMoods() []string {
+	moods := make([]string, 0, len(presetBGMs))
+	for k := range presetBGMs {
+		moods = append(moods, k)
+	}
+	return moods
+}

--- a/internal/live/tools.go
+++ b/internal/live/tools.go
@@ -150,13 +150,14 @@ func (h *ToolHandler) handleChangeAtmosphere(ctx context.Context, args map[strin
 		return errResp, nil
 	}
 
+	bgm := GetPresetBGMURL(mood)
 	h.emitEvent(map[string]any{
-		"type": "atmosphere_change",
-		"mood": mood,
+		"type":    "atmosphere_change",
+		"mood":    bgm.Mood,
+		"bgm_url": bgm.URL,
 	})
 
-	// TODO: T15 - Preset BGM selection + crossfade
-	return map[string]any{"status": "atmosphere changed", "mood": mood}, nil
+	return map[string]any{"status": "atmosphere changed", "mood": bgm.Mood, "bgm_url": bgm.URL}, nil
 }
 
 func (h *ToolHandler) handleRecallMemory(ctx context.Context, args map[string]any) (map[string]any, error) {

--- a/internal/live/tools_test.go
+++ b/internal/live/tools_test.go
@@ -213,3 +213,91 @@ func TestToolHandler_ResumptionToken(t *testing.T) {
 		t.Fatalf("expected token 'test-token-123', got %q", token)
 	}
 }
+
+func TestGetPresetBGMURL_AllMoods(t *testing.T) {
+	moods := []string{"warm", "romantic", "nostalgic", "playful", "emotional", "farewell"}
+	for _, mood := range moods {
+		bgm := GetPresetBGMURL(mood)
+		if bgm.Mood != mood {
+			t.Fatalf("expected mood %q, got %q", mood, bgm.Mood)
+		}
+		if bgm.URL == "" {
+			t.Fatalf("expected non-empty URL for mood %q", mood)
+		}
+	}
+}
+
+func TestGetPresetBGMURL_UnknownMood(t *testing.T) {
+	bgm := GetPresetBGMURL("unknown_mood")
+	if bgm.Mood != "nostalgic" {
+		t.Fatalf("expected fallback to 'nostalgic', got %q", bgm.Mood)
+	}
+	if bgm.URL == "" {
+		t.Fatal("expected non-empty fallback URL")
+	}
+}
+
+func TestHandleChangeAtmosphere_WriteJSON(t *testing.T) {
+	h := NewToolHandler()
+
+	var mu sync.Mutex
+	var events []map[string]any
+
+	h.SetEventSender(func(v any) {
+		mu.Lock()
+		defer mu.Unlock()
+		if m, ok := v.(map[string]any); ok {
+			events = append(events, m)
+		}
+	})
+
+	result, err := h.Handle(context.Background(), "change_atmosphere", map[string]any{"mood": "warm"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Check result contains bgm_url.
+	if result["bgm_url"] == nil || result["bgm_url"] == "" {
+		t.Fatal("expected bgm_url in result")
+	}
+
+	// Check event contains bgm_url and mood.
+	mu.Lock()
+	defer mu.Unlock()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	ev := events[0]
+	if ev["type"] != "atmosphere_change" {
+		t.Fatalf("expected type 'atmosphere_change', got %q", ev["type"])
+	}
+	if ev["bgm_url"] == nil || ev["bgm_url"] == "" {
+		t.Fatal("expected bgm_url in event")
+	}
+	if ev["mood"] != "warm" {
+		t.Fatalf("expected mood 'warm', got %q", ev["mood"])
+	}
+}
+
+func TestAllPresetMoods(t *testing.T) {
+	moods := AllPresetMoods()
+	if len(moods) != 6 {
+		t.Fatalf("expected 6 preset moods, got %d", len(moods))
+	}
+
+	expected := map[string]bool{
+		"warm": false, "romantic": false, "nostalgic": false,
+		"playful": false, "emotional": false, "farewell": false,
+	}
+	for _, m := range moods {
+		if _, ok := expected[m]; !ok {
+			t.Fatalf("unexpected mood %q", m)
+		}
+		expected[m] = true
+	}
+	for m, found := range expected {
+		if !found {
+			t.Fatalf("missing mood %q", m)
+		}
+	}
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -6,6 +6,7 @@ import { useAudio } from '../hooks/useAudio';
 import SceneDisplay from '../components/SceneDisplay';
 import SessionTransition from '../components/SessionTransition';
 import OnboardingFlow, { type OnboardingStage } from '../components/OnboardingFlow';
+import BGMPlayer from '../components/BGMPlayer';
 import type { YouTubeVideo } from '../components/YouTubeGrid';
 import type { Highlight } from '../components/HighlightCard';
 
@@ -33,6 +34,7 @@ export default function Home() {
   const [highlights, setHighlights] = useState<Highlight[]>([]);
   const [analysisStep, setAnalysisStep] = useState('');
   const [analysisPercent, setAnalysisPercent] = useState(0);
+  const [bgmUrl, setBgmUrl] = useState<string | null>(null);
 
   const { initAudioContext, playPCM, cleanup: cleanupAudio } = useAudio();
 
@@ -65,6 +67,11 @@ export default function Home() {
       case 'person_detected':
         setPersonCrops(msg.crops);
         setOnboardingStage('person_select');
+        break;
+      case 'atmosphere_change':
+        if (msg.bgm_url) {
+          setBgmUrl(msg.bgm_url);
+        }
         break;
       case 'analysis_progress':
         setOnboardingStage('analyzing');
@@ -125,6 +132,7 @@ export default function Home() {
     setHighlights([]);
     setAnalysisStep('');
     setAnalysisPercent(0);
+    setBgmUrl(null);
   };
 
   const handleSelectVideo = useCallback((videoId: string) => {
@@ -176,6 +184,7 @@ export default function Home() {
   return (
     <main style={{ position: 'relative', height: '100dvh', width: '100dvw' }}>
       <SceneDisplay previewSrc={previewSrc} finalSrc={finalSrc} />
+      <BGMPlayer bgmUrl={bgmUrl} />
       <SessionTransition phase={transition} />
       <OnboardingFlow
         stage={onboardingStage}

--- a/web/components/BGMPlayer.tsx
+++ b/web/components/BGMPlayer.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+
+/** Volume level for BGM (-20dB relative to full scale). */
+const BGM_VOLUME = 0.1;
+/** Crossfade duration in milliseconds. */
+const CROSSFADE_MS = 2000;
+
+interface BGMPlayerProps {
+  /** Current BGM URL to play. null stops playback. */
+  bgmUrl: string | null;
+}
+
+export default function BGMPlayer({ bgmUrl }: BGMPlayerProps) {
+  const currentAudioRef = useRef<HTMLAudioElement | null>(null);
+  const nextAudioRef = useRef<HTMLAudioElement | null>(null);
+  const fadeIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const clearFade = useCallback(() => {
+    if (fadeIntervalRef.current) {
+      clearInterval(fadeIntervalRef.current);
+      fadeIntervalRef.current = null;
+    }
+  }, []);
+
+  const crossfadeTo = useCallback((url: string) => {
+    clearFade();
+
+    const next = new Audio(url);
+    next.loop = true;
+    next.volume = 0;
+    nextAudioRef.current = next;
+
+    const prev = currentAudioRef.current;
+    const steps = CROSSFADE_MS / 50;
+    let step = 0;
+
+    next.play().catch(() => {
+      // Autoplay may be blocked; BGM is non-critical.
+    });
+
+    fadeIntervalRef.current = setInterval(() => {
+      step++;
+      const progress = Math.min(step / steps, 1);
+
+      next.volume = BGM_VOLUME * progress;
+      if (prev) {
+        prev.volume = BGM_VOLUME * (1 - progress);
+      }
+
+      if (progress >= 1) {
+        clearFade();
+        if (prev) {
+          prev.pause();
+          prev.src = '';
+        }
+        currentAudioRef.current = next;
+        nextAudioRef.current = null;
+      }
+    }, 50);
+  }, [clearFade]);
+
+  const stopBGM = useCallback(() => {
+    clearFade();
+    if (currentAudioRef.current) {
+      currentAudioRef.current.pause();
+      currentAudioRef.current.src = '';
+      currentAudioRef.current = null;
+    }
+    if (nextAudioRef.current) {
+      nextAudioRef.current.pause();
+      nextAudioRef.current.src = '';
+      nextAudioRef.current = null;
+    }
+  }, [clearFade]);
+
+  useEffect(() => {
+    if (!bgmUrl) {
+      stopBGM();
+      return;
+    }
+
+    // If same URL is already playing, skip.
+    if (currentAudioRef.current && currentAudioRef.current.src.endsWith(bgmUrl)) {
+      return;
+    }
+
+    crossfadeTo(bgmUrl);
+  }, [bgmUrl, crossfadeTo, stopBGM]);
+
+  // Cleanup on unmount.
+  useEffect(() => {
+    return () => {
+      stopBGM();
+    };
+  }, [stopBGM]);
+
+  // This component renders nothing visible.
+  return null;
+}

--- a/web/hooks/useWebSocket.ts
+++ b/web/hooks/useWebSocket.ts
@@ -4,7 +4,7 @@ export type ServerMessage =
   | { type: 'audio'; data: ArrayBuffer }
   | { type: 'scene_preview'; image: string }
   | { type: 'scene_final'; image: string }
-  | { type: 'bgm_change'; mood: string; audioUrl: string }
+  | { type: 'atmosphere_change'; mood: string; bgm_url: string }
   | { type: 'tool_error'; tool: string; message: string }
   | { type: 'session_transition' }
   | { type: 'session_ready' }


### PR DESCRIPTION
## Summary
- Add 6 preset BGMs (warm/romantic/nostalgic/playful/emotional/farewell) with URL mapping
- `GetPresetBGMURL()` returns mood-matched BGM, falls back to nostalgic for unknown moods
- `handleChangeAtmosphere` sends `bgm_url` in `atmosphere_change` event to browser
- `BGMPlayer` component with -20dB volume level and 2s crossfade transition
- Integrated into `page.tsx` with `atmosphere_change` WebSocket message handling
- Updated `ServerMessage` type to align with backend event format

## Issue
Closes #20

## Local CI
- [x] go build ./... passed
- [x] go vet ./... passed
- [x] go test -race ./... passed (all 14 packages)
- [x] tsc --noEmit passed
- [x] npm run build passed

## Test plan
- Verify all 6 moods return correct BGM URLs
- Verify unknown mood falls back to nostalgic
- Verify atmosphere_change event includes bgm_url field
- Verify BGMPlayer crossfades between tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 배경음악 기능 추가: 다양한 분위기(무드)에 맞는 배경음악 제공
  * 분위기 변경 시 음악이 자동으로 부드럽게 전환되는 크로스페이드 효과 적용

* **테스트**
  * 배경음악 프리셋 및 분위기 변경 기능에 대한 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->