### PR TITLE
feat: recall_memory with keyword search and batch save (#21)

### DIFF
--- a/internal/live/tools.go
+++ b/internal/live/tools.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Two-Weeks-Team/missless/internal/memory"
 	"github.com/Two-Weeks-Team/missless/internal/scene"
 )
 
@@ -19,6 +20,10 @@ type ToolHandler struct {
 	sendEvent func(v any)
 	// generator handles image generation (nil until SetGenerator is called).
 	generator *scene.Generator
+	// memoryStore handles memory search for recall_memory tool.
+	memoryStore *memory.Store
+	// personaID is the current persona identifier for memory lookups.
+	personaID string
 }
 
 // NewToolHandler creates a new tool handler.
@@ -31,6 +36,14 @@ func (h *ToolHandler) SetGenerator(gen *scene.Generator) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.generator = gen
+}
+
+// SetMemoryStore sets the memory store for recall_memory.
+func (h *ToolHandler) SetMemoryStore(store *memory.Store, personaID string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.memoryStore = store
+	h.personaID = personaID
 }
 
 // getGenerator returns the current generator under lock.
@@ -166,8 +179,32 @@ func (h *ToolHandler) handleRecallMemory(ctx context.Context, args map[string]an
 		return errResp, nil
 	}
 
-	// TODO: T16 - Firestore memory search
-	return map[string]any{"memories": []string{}, "query": query}, nil
+	h.mu.RLock()
+	store := h.memoryStore
+	pid := h.personaID
+	h.mu.RUnlock()
+
+	if store == nil || pid == "" {
+		return map[string]any{"memories": []any{}, "query": query}, nil
+	}
+
+	memories, err := store.Search(ctx, pid, query)
+	if err != nil {
+		slog.Warn("memory_search_failed", "error", err)
+		return map[string]any{"memories": []any{}, "query": query}, nil
+	}
+
+	// Format memories for AI consumption.
+	results := make([]map[string]string, 0, len(memories))
+	for _, m := range memories {
+		results = append(results, map[string]string{
+			"timestamp":   m.Timestamp,
+			"description": m.Description,
+			"expression":  m.Expression,
+		})
+	}
+
+	return map[string]any{"memories": results, "query": query, "count": len(results)}, nil
 }
 
 func (h *ToolHandler) handleAnalyzeUser(ctx context.Context, args map[string]any) (map[string]any, error) {

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 )
@@ -14,53 +15,174 @@ type Memory struct {
 	Topic       string    `json:"topic" firestore:"topic"`
 	Description string    `json:"description" firestore:"description"`
 	Timestamp   string    `json:"timestamp" firestore:"timestamp"`
+	Expression  string    `json:"expression" firestore:"expression"`
 	Source      string    `json:"source" firestore:"source"` // "video_analysis" | "user_input"
 	CreatedAt   time.Time `json:"createdAt" firestore:"createdAt"`
 }
 
-// Store manages persona memories in Firestore.
-// Lock ordering: MemoryStore.mu is Level 6 (lowest).
+// AnalysisHighlight is the input format from video analysis.
+type AnalysisHighlight struct {
+	Timestamp   string `json:"timestamp"`
+	Description string `json:"description"`
+	Expression  string `json:"expression"`
+}
+
+// Store manages persona memories (in-memory for hackathon; Firestore-ready interface).
+// Lock ordering: Store.mu is Level 6 (lowest).
 type Store struct {
 	mu        sync.RWMutex
-	cache     map[string][]Memory // LRU cache with size limit
-	maxCache  int
-	projectID string
-	// TODO: T16 - Add firestore.Client field
+	memories  map[string][]Memory // personaID → memories
+	maxPerKey int
 }
 
 // NewStore creates a new memory store.
-func NewStore(projectID string, maxCache int) *Store {
+func NewStore(maxPerKey int) *Store {
 	return &Store{
-		cache:     make(map[string][]Memory),
-		maxCache:  maxCache,
-		projectID: projectID,
+		memories:  make(map[string][]Memory),
+		maxPerKey: maxPerKey,
 	}
 }
 
-// Search finds memories by topic keywords.
-func (s *Store) Search(ctx context.Context, personaID, topic string) ([]Memory, error) {
-	slog.Info("memory_search", "persona", personaID, "topic", topic)
-
-	// Check cache first
-	s.mu.RLock()
-	if cached, ok := s.cache[personaID+":"+topic]; ok {
-		s.mu.RUnlock()
-		return cached, nil
+// SaveFromAnalysis batch-saves highlights from video analysis as memories.
+func (s *Store) SaveFromAnalysis(ctx context.Context, personaID string, highlights []AnalysisHighlight) error {
+	if len(highlights) == 0 {
+		return nil
 	}
-	s.mu.RUnlock()
 
-	// TODO: T16 - Firestore query: personas/{personaId}/memories
-	// WHERE keywords array-contains-any [topic keywords]
-	// LIMIT 10, ORDER BY relevance DESC
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-	return nil, fmt.Errorf("not yet implemented")
+	now := time.Now()
+	for i, h := range highlights {
+		mem := Memory{
+			ID:          fmt.Sprintf("%s-analysis-%d", personaID, i),
+			Topic:       extractTopics(h.Description),
+			Description: h.Description,
+			Timestamp:   h.Timestamp,
+			Expression:  h.Expression,
+			Source:      "video_analysis",
+			CreatedAt:   now,
+		}
+		s.memories[personaID] = append(s.memories[personaID], mem)
+	}
+
+	// Trim to max.
+	if len(s.memories[personaID]) > s.maxPerKey {
+		s.memories[personaID] = s.memories[personaID][len(s.memories[personaID])-s.maxPerKey:]
+	}
+
+	slog.Info("memory_batch_saved", "persona", personaID, "count", len(highlights))
+	return nil
 }
 
-// Save stores a new memory.
+// Save stores a single memory.
 func (s *Store) Save(ctx context.Context, personaID string, memory Memory) error {
-	slog.Info("memory_save", "persona", personaID, "topic", memory.Topic)
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-	// TODO: T16 - Write to personas/{personaId}/memories/{memoryId}
+	if memory.CreatedAt.IsZero() {
+		memory.CreatedAt = time.Now()
+	}
 
-	return fmt.Errorf("not yet implemented")
+	s.memories[personaID] = append(s.memories[personaID], memory)
+
+	if len(s.memories[personaID]) > s.maxPerKey {
+		s.memories[personaID] = s.memories[personaID][len(s.memories[personaID])-s.maxPerKey:]
+	}
+
+	slog.Info("memory_saved", "persona", personaID, "topic", memory.Topic)
+	return nil
+}
+
+// Search finds memories matching the query keywords.
+// Returns at most 10 results sorted by relevance (match count).
+func (s *Store) Search(ctx context.Context, personaID, query string) ([]Memory, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	mems, ok := s.memories[personaID]
+	if !ok || len(mems) == 0 {
+		return nil, nil
+	}
+
+	keywords := splitKeywords(query)
+	if len(keywords) == 0 {
+		return nil, nil
+	}
+
+	type scored struct {
+		mem   Memory
+		score int
+	}
+
+	var results []scored
+	for _, m := range mems {
+		score := matchScore(m, keywords)
+		if score > 0 {
+			results = append(results, scored{mem: m, score: score})
+		}
+	}
+
+	// Sort by score descending (simple insertion sort for small N).
+	for i := 1; i < len(results); i++ {
+		for j := i; j > 0 && results[j].score > results[j-1].score; j-- {
+			results[j], results[j-1] = results[j-1], results[j]
+		}
+	}
+
+	limit := 10
+	if len(results) < limit {
+		limit = len(results)
+	}
+
+	out := make([]Memory, limit)
+	for i := 0; i < limit; i++ {
+		out[i] = results[i].mem
+	}
+
+	slog.Info("memory_search", "persona", personaID, "query", query, "found", len(out))
+	return out, nil
+}
+
+// Count returns the number of memories for a persona.
+func (s *Store) Count(personaID string) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.memories[personaID])
+}
+
+// matchScore returns how many keywords match in a memory's topic and description.
+func matchScore(m Memory, keywords []string) int {
+	score := 0
+	lower := strings.ToLower(m.Topic + " " + m.Description)
+	for _, kw := range keywords {
+		if ContainsKeyword(lower, kw) {
+			score++
+		}
+	}
+	return score
+}
+
+// ContainsKeyword checks if text contains the keyword (case-insensitive).
+func ContainsKeyword(text, keyword string) bool {
+	return strings.Contains(strings.ToLower(text), strings.ToLower(keyword))
+}
+
+// splitKeywords splits a query into individual keywords.
+func splitKeywords(query string) []string {
+	parts := strings.Fields(strings.ToLower(query))
+	var keywords []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if len(p) > 0 {
+			keywords = append(keywords, p)
+		}
+	}
+	return keywords
+}
+
+// extractTopics creates a topic string from a description by taking key words.
+func extractTopics(description string) string {
+	// Simple: use the description itself as the topic for keyword matching.
+	return strings.ToLower(description)
 }

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1,0 +1,180 @@
+package memory
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMemoryStore_SaveFromAnalysis(t *testing.T) {
+	store := NewStore(100)
+	ctx := context.Background()
+
+	highlights := []AnalysisHighlight{
+		{Timestamp: "0:15", Description: "카페에서 함께 커피를 마시며 웃는 모습", Expression: "happy"},
+		{Timestamp: "1:30", Description: "공원에서 산책하며 대화하는 장면", Expression: "calm"},
+		{Timestamp: "3:00", Description: "생일 파티에서 케이크를 자르는 모습", Expression: "joyful"},
+	}
+
+	err := store.SaveFromAnalysis(ctx, "persona-1", highlights)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if store.Count("persona-1") != 3 {
+		t.Fatalf("expected 3 memories, got %d", store.Count("persona-1"))
+	}
+}
+
+func TestMemoryStore_SaveFromAnalysis_Empty(t *testing.T) {
+	store := NewStore(100)
+	ctx := context.Background()
+
+	err := store.SaveFromAnalysis(ctx, "persona-1", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if store.Count("persona-1") != 0 {
+		t.Fatalf("expected 0 memories, got %d", store.Count("persona-1"))
+	}
+}
+
+func TestMemoryStore_Search_Found(t *testing.T) {
+	store := NewStore(100)
+	ctx := context.Background()
+
+	highlights := []AnalysisHighlight{
+		{Timestamp: "0:15", Description: "카페에서 함께 커피를 마시며 웃는 모습", Expression: "happy"},
+		{Timestamp: "1:30", Description: "공원에서 산책하며 대화하는 장면", Expression: "calm"},
+		{Timestamp: "3:00", Description: "카페에서 생일 파티를 하는 모습", Expression: "joyful"},
+	}
+	_ = store.SaveFromAnalysis(ctx, "persona-1", highlights)
+
+	results, err := store.Search(ctx, "persona-1", "카페")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results for '카페', got %d", len(results))
+	}
+}
+
+func TestMemoryStore_Search_NotFound(t *testing.T) {
+	store := NewStore(100)
+	ctx := context.Background()
+
+	highlights := []AnalysisHighlight{
+		{Timestamp: "0:15", Description: "카페에서 함께 커피를 마시며 웃는 모습", Expression: "happy"},
+	}
+	_ = store.SaveFromAnalysis(ctx, "persona-1", highlights)
+
+	results, err := store.Search(ctx, "persona-1", "학교")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results for '학교', got %d", len(results))
+	}
+}
+
+func TestMemoryStore_Search_EmptyStore(t *testing.T) {
+	store := NewStore(100)
+	ctx := context.Background()
+
+	results, err := store.Search(ctx, "nonexistent", "anything")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if results != nil {
+		t.Fatalf("expected nil results, got %v", results)
+	}
+}
+
+func TestContainsKeyword(t *testing.T) {
+	tests := []struct {
+		text    string
+		keyword string
+		want    bool
+	}{
+		{"카페에서 커피를 마시는 모습", "카페", true},
+		{"공원에서 산책하는 모습", "카페", false},
+		{"Hello World", "world", true}, // case insensitive
+		{"Hello World", "WORLD", true}, // case insensitive
+		{"", "test", false},
+		{"some text", "", true},
+	}
+
+	for _, tc := range tests {
+		got := ContainsKeyword(tc.text, tc.keyword)
+		if got != tc.want {
+			t.Errorf("ContainsKeyword(%q, %q) = %v, want %v", tc.text, tc.keyword, got, tc.want)
+		}
+	}
+}
+
+func TestMemoryStore_Save_Single(t *testing.T) {
+	store := NewStore(100)
+	ctx := context.Background()
+
+	err := store.Save(ctx, "persona-1", Memory{
+		ID:          "mem-1",
+		Topic:       "여행",
+		Description: "제주도 여행에서 찍은 사진",
+		Timestamp:   "2:00",
+		Source:      "user_input",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if store.Count("persona-1") != 1 {
+		t.Fatalf("expected 1 memory, got %d", store.Count("persona-1"))
+	}
+
+	results, _ := store.Search(ctx, "persona-1", "제주도")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 search result, got %d", len(results))
+	}
+}
+
+func TestMemoryStore_MaxLimit(t *testing.T) {
+	store := NewStore(5)
+	ctx := context.Background()
+
+	for i := 0; i < 10; i++ {
+		_ = store.Save(ctx, "persona-1", Memory{
+			ID:          "mem",
+			Topic:       "topic",
+			Description: "desc",
+			Source:      "user_input",
+		})
+	}
+
+	if store.Count("persona-1") != 5 {
+		t.Fatalf("expected max 5 memories, got %d", store.Count("persona-1"))
+	}
+}
+
+func TestMemoryStore_Search_MultiKeyword(t *testing.T) {
+	store := NewStore(100)
+	ctx := context.Background()
+
+	highlights := []AnalysisHighlight{
+		{Timestamp: "0:15", Description: "카페에서 커피를 마시며 웃는 모습", Expression: "happy"},
+		{Timestamp: "1:30", Description: "카페에서 커피와 케이크를 먹는 장면", Expression: "calm"},
+		{Timestamp: "3:00", Description: "공원에서 케이크를 먹는 모습", Expression: "joyful"},
+	}
+	_ = store.SaveFromAnalysis(ctx, "persona-1", highlights)
+
+	// "카페 케이크" should rank the second highlight highest (matches both).
+	results, err := store.Search(ctx, "persona-1", "카페 케이크")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+	// First result should have score 2 (matches both keywords).
+	if !ContainsKeyword(results[0].Description, "카페") || !ContainsKeyword(results[0].Description, "케이크") {
+		t.Fatalf("expected first result to match both keywords, got: %s", results[0].Description)
+	}
+}


### PR DESCRIPTION
## Summary
- Implement in-memory `Store` with `SaveFromAnalysis` batch save from video analysis highlights
- Keyword-based `Search` with multi-keyword scoring and relevance ranking (top 10)
- Integrate memory store into `ToolHandler.handleRecallMemory` for persona-scoped lookups
- `ContainsKeyword` utility for case-insensitive keyword matching
- Max memory limit per persona with FIFO eviction

## Issue
Closes #21

## Local CI
- [x] go build ./... passed
- [x] go vet ./... passed
- [x] go test -race ./... passed (all 15 packages, including new memory package)

## Test plan
- Verify batch save stores correct count of memories
- Verify search finds memories matching keywords
- Verify search returns empty for non-matching keywords
- Verify multi-keyword search ranks by match count
- Verify max limit enforces FIFO eviction
- Verify ContainsKeyword handles case insensitivity and edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)