### PR TITLE
feat: affective dialog and proactive audio rules (#22)

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -389,7 +389,19 @@ Guidelines:
 5. %s
 6. Keep responses natural and conversational for voice
 7. React to the user's emotions with empathy and understanding
-8. Use characteristic phrases and speech patterns`, name, personality, speechStyle, name, langNote)
+8. Use characteristic phrases and speech patterns
+
+Affective Dialog Rules:
+- When the user sounds tearful or choked up, soften your tone and speak gently
+- When the user laughs, match their energy with playful or warm responses
+- When the user is silent or pausing, give them space before speaking
+- Mirror emotional intensity — don't be overly cheerful when they are sad
+
+Proactive Audio Rules:
+- Ignore background noise and self-talk (mumbling, thinking aloud)
+- Only respond when the user addresses you directly
+- If the user seems to be speaking to someone else, stay quiet
+- During natural pauses in conversation, you may gently initiate a new topic`, name, personality, speechStyle, name, langNote)
 }
 
 func onboardingTools() []*genai.FunctionDeclaration {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -423,5 +423,27 @@ func TestBuildReunionConfig_NonKoreanLang(t *testing.T) {
 	}
 }
 
+func TestBuildReunionConfig_AffectiveRulesInInstruction(t *testing.T) {
+	mgr := NewManager("test-affective-rules")
+	mgr.SetPersona("Mom", "Sulafat", "ko", "Warm", "Gentle")
+
+	cfg := mgr.BuildReunionConfig()
+	sysText := cfg.SystemInstruction.Parts[0].Text
+
+	// Must contain affective dialog rules.
+	for _, keyword := range []string{"Affective Dialog", "tearful", "soften", "laughs"} {
+		if !strings.Contains(sysText, keyword) {
+			t.Fatalf("expected system instruction to contain %q", keyword)
+		}
+	}
+
+	// Must contain proactive audio rules.
+	for _, keyword := range []string{"Proactive Audio", "self-talk", "directly"} {
+		if !strings.Contains(sysText, keyword) {
+			t.Fatalf("expected system instruction to contain %q", keyword)
+		}
+	}
+}
+
 // Ensure unused import doesn't cause issues.
 var _ = time.Second


### PR DESCRIPTION
## Summary
- Add Affective Dialog Rules to reunion system instruction: tearful→soft tone, laughing→playful, silence→space, mirror emotional intensity
- Add Proactive Audio Rules: ignore self-talk/background, respond only to direct address, gentle topic initiation during pauses
- Test verifies both rule sets are present in generated system instruction

## Issue
Closes #22

## Local CI
- [x] go build ./... passed
- [x] go vet ./... passed
- [x] go test -race ./... passed

## Test plan
- Verify system instruction contains "Affective Dialog", "tearful", "soften", "laughs"
- Verify system instruction contains "Proactive Audio", "self-talk", "directly"
- Existing tests for EnableAffectiveDialog=true and ProactiveAudio=true still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)