### PR TITLE
feat: Cloud Run deploy config with WebSocket support (#25)

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -6,7 +6,7 @@
 # ============================================================
 
 # Stage 1: Go Build
-FROM golang:1.22-alpine AS builder
+FROM golang:1.25-alpine AS builder
 WORKDIR /app
 
 COPY go.mod go.sum ./

--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -9,23 +9,23 @@ steps:
     args:
       - 'build'
       - '-t'
-      - 'gcr.io/$PROJECT_ID/missless:$COMMIT_SHA'
+      - 'asia-northeast3-docker.pkg.dev/$PROJECT_ID/missless/server:$COMMIT_SHA'
       - '-t'
-      - 'gcr.io/$PROJECT_ID/missless:latest'
+      - 'asia-northeast3-docker.pkg.dev/$PROJECT_ID/missless/server:latest'
       - '-f'
       - 'deploy/Dockerfile'
       - '.'
 
-  # Step 2: Push to Container Registry
+  # Step 2: Push to Artifact Registry
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'push'
-      - 'gcr.io/$PROJECT_ID/missless:$COMMIT_SHA'
+      - 'asia-northeast3-docker.pkg.dev/$PROJECT_ID/missless/server:$COMMIT_SHA'
 
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'push'
-      - 'gcr.io/$PROJECT_ID/missless:latest'
+      - 'asia-northeast3-docker.pkg.dev/$PROJECT_ID/missless/server:latest'
 
   # Step 3: Deploy to Cloud Run
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
@@ -34,7 +34,7 @@ steps:
       - 'run'
       - 'deploy'
       - 'missless'
-      - '--image=gcr.io/$PROJECT_ID/missless:$COMMIT_SHA'
+      - '--image=asia-northeast3-docker.pkg.dev/$PROJECT_ID/missless/server:$COMMIT_SHA'
       - '--region=asia-northeast3'
       - '--platform=managed'
       - '--allow-unauthenticated'
@@ -42,15 +42,16 @@ steps:
       - '--max-instances=10'
       - '--memory=512Mi'
       - '--cpu=1'
-      - '--timeout=300'
+      - '--timeout=3600'
       - '--concurrency=80'
+      - '--session-affinity'
       - '--service-account=missless-backend@$PROJECT_ID.iam.gserviceaccount.com'
       - '--set-env-vars=GCP_PROJECT_ID=$PROJECT_ID,ENVIRONMENT=production,DOMAIN=missless.co'
       - '--set-secrets=GEMINI_API_KEY=gemini-api-key:latest,SESSION_SECRET=session-secret:latest,YOUTUBE_CLIENT_ID=youtube-client-id:latest,YOUTUBE_CLIENT_SECRET=youtube-client-secret:latest'
 
 images:
-  - 'gcr.io/$PROJECT_ID/missless:$COMMIT_SHA'
-  - 'gcr.io/$PROJECT_ID/missless:latest'
+  - 'asia-northeast3-docker.pkg.dev/$PROJECT_ID/missless/server:$COMMIT_SHA'
+  - 'asia-northeast3-docker.pkg.dev/$PROJECT_ID/missless/server:latest'
 
 options:
   machineType: 'N1_HIGHCPU_8'

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -109,8 +109,10 @@ resource "google_cloud_run_v2_service" "missless" {
       max_instance_count = 10
     }
 
+    session_affinity = true
+
     containers {
-      image = "gcr.io/${var.project_id}/missless:latest"
+      image = "asia-northeast3-docker.pkg.dev/${var.project_id}/missless/server:latest"
 
       ports {
         container_port = 8080
@@ -141,7 +143,7 @@ resource "google_cloud_run_v2_service" "missless" {
       }
     }
 
-    timeout = "300s"
+    timeout = "3600s"
   }
 }
 


### PR DESCRIPTION
## Summary
- Update Dockerfile Go version from 1.22 to 1.25 (matching go.mod)
- Migrate container registry from GCR to Artifact Registry (asia-northeast3)
- Add `--session-affinity` for WebSocket sticky sessions on Cloud Run
- Increase timeout from 300s to 3600s for long-running WebSocket connections
- Update Terraform with `session_affinity = true` and Artifact Registry image path

## Issue
Closes #25

## Local CI
- [x] go build ./... passed
- [x] go vet ./... passed
- [x] go test -race ./... passed

## Test plan
- `docker build -f deploy/Dockerfile .` should succeed
- Cloud Run deployment with `--session-affinity` enables WebSocket support
- Health check endpoint `/health` returns 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)