### PR TITLE
fix: implement http.Hijacker in logging middleware for WebSocket

### DIFF
--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -54,7 +54,7 @@ images:
   - 'asia-northeast3-docker.pkg.dev/$PROJECT_ID/missless/server:latest'
 
 options:
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'E2_HIGHCPU_8'
   logging: CLOUD_LOGGING_ONLY
 
 timeout: '600s'

--- a/internal/middleware/logging.go
+++ b/internal/middleware/logging.go
@@ -1,7 +1,10 @@
 package middleware
 
 import (
+	"bufio"
+	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"time"
 )
@@ -14,6 +17,14 @@ type responseWriter struct {
 func (rw *responseWriter) WriteHeader(code int) {
 	rw.statusCode = code
 	rw.ResponseWriter.WriteHeader(code)
+}
+
+// Hijack implements http.Hijacker so WebSocket upgrades work through this middleware.
+func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := rw.ResponseWriter.(http.Hijacker); ok {
+		return hj.Hijack()
+	}
+	return nil, nil, fmt.Errorf("underlying ResponseWriter does not implement http.Hijacker")
 }
 
 // Logging logs every HTTP request with method, path, status, and duration.


### PR DESCRIPTION
## Summary
- Add `Hijack()` method to logging middleware's `responseWriter` so it implements `http.Hijacker`
- Fix `cloudbuild.yaml` machineType from `N1_HIGHCPU_8` to `E2_HIGHCPU_8` for asia-northeast3 region

## Root Cause
gorilla/websocket's `Upgrade()` requires `http.Hijacker` on the `ResponseWriter`. The logging middleware wraps the writer but did not delegate `Hijack()`, causing `"response does not implement http.Hijacker"` on Cloud Run.

## Local CI
- [x] go vet passed
- [x] go test -race passed (all 14 packages)
- [x] go build passed

## Test plan
- Deploy to Cloud Run and verify WebSocket `/ws` endpoint connects successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * WebSocket 업그레이드가 이제 미들웨어를 통해 정상적으로 작동합니다.

* **유지보수**
  * 인프라 구성을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->