### PR TITLE
fix: remove Transparent session resumption for Developer API

### DIFF
--- a/internal/handler/websocket_test.go
+++ b/internal/handler/websocket_test.go
@@ -66,9 +66,7 @@ func TestBuildOnboardingConfig(t *testing.T) {
 	if cfg.SessionResumption == nil {
 		t.Fatal("expected SessionResumption config")
 	}
-	if !cfg.SessionResumption.Transparent {
-		t.Fatal("expected transparent session resumption")
-	}
+	// SessionResumption exists (Transparent removed for Developer API compatibility).
 }
 
 func TestBuildOnboardingConfig_Modalities(t *testing.T) {

--- a/internal/live/reconnect.go
+++ b/internal/live/reconnect.go
@@ -35,7 +35,7 @@ func (p *Proxy) Reconnect(ctx context.Context, client *genai.Client, model strin
 	// Shallow copy config to avoid mutating the caller's original.
 	cfg := *config
 	if token != "" {
-		resumption := &genai.SessionResumptionConfig{Transparent: true}
+		resumption := &genai.SessionResumptionConfig{}
 		if config.SessionResumption != nil {
 			*resumption = *config.SessionResumption
 		}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -189,9 +189,7 @@ Keep responses concise for voice — avoid long monologues.`),
 				FunctionDeclarations: onboardingTools(),
 			},
 		},
-		SessionResumption: &genai.SessionResumptionConfig{
-			Transparent: true,
-		},
+		SessionResumption: &genai.SessionResumptionConfig{},
 	}
 }
 
@@ -245,9 +243,7 @@ func (m *Manager) BuildReunionConfig() *genai.LiveConnectConfig {
 				FunctionDeclarations: reunionTools(),
 			},
 		},
-		SessionResumption: &genai.SessionResumptionConfig{
-			Transparent: true,
-		},
+		SessionResumption: &genai.SessionResumptionConfig{},
 	}
 }
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -73,9 +73,9 @@ func TestManager_StartOnboarding_Config(t *testing.T) {
 		}
 	}
 
-	// Session resumption must be transparent.
-	if cfg.SessionResumption == nil || !cfg.SessionResumption.Transparent {
-		t.Fatal("expected transparent session resumption")
+	// Session resumption must be configured.
+	if cfg.SessionResumption == nil {
+		t.Fatal("expected session resumption config")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Remove `Transparent: true` from `SessionResumptionConfig` in onboarding, reunion, and reconnect configs
- Gemini Developer API (`BackendGeminiAPI`) does not support this parameter (Vertex AI only)

## Root Cause
Server logs showed: `transparent parameter is not supported in Gemini API`
This caused Live API connection to fail after WebSocket handshake succeeded.

## Local CI
- [x] go vet passed
- [x] go test -race passed (all 14 packages)

## Test plan
- Redeploy to Cloud Run and verify Live API connects without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 세션 복구 설정 구조가 단순화되었습니다. 기본 세션 복구 구성이 변경되어 더욱 유연한 동작을 지원합니다.
  * 세션 재개 시 기본 설정 처리가 개선되었습니다.
  * 내부 세션 관리 검증 로직이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->