### PR TITLE
fix: use correct Developer API model ID for Live API

### DIFF
--- a/internal/handler/websocket.go
+++ b/internal/handler/websocket.go
@@ -17,7 +17,7 @@ import (
 )
 
 // LiveModel is the Gemini model used for the Live API connection.
-const LiveModel = "gemini-2.5-flash-native-audio"
+const LiveModel = "gemini-2.5-flash-native-audio-preview-12-2025"
 
 // newUpgrader creates a WebSocket upgrader with origin checking based on environment.
 func newUpgrader(cfg *config.Config) websocket.Upgrader {


### PR DESCRIPTION
## Summary
- Change `LiveModel` from `gemini-2.5-flash-native-audio` to `gemini-2.5-flash-native-audio-preview-12-2025`

## Root Cause
`gemini-2.5-flash-native-audio` does not exist as a model ID in Developer API v1alpha.
Server logs: `models/gemini-2.5-flash-native-audio is not found for API version v1alpha`

Available models confirmed via API:
- `gemini-2.5-flash-native-audio-latest`
- `gemini-2.5-flash-native-audio-preview-12-2025`
- `gemini-2.5-flash-native-audio-preview-09-2025`

## Local CI
- [x] go vet passed
- [x] go test -race passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)