### PR TITLE
fix(main): replace bare go func() with util.SafeGo()

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -60,12 +60,12 @@ func main() {
 	}
 
 	// Start server
-	go func() {
+	util.SafeGo(func() {
 		slog.Info("server started", "port", cfg.Port)
 		if err := server.ListenAndServe(); err != http.ErrServerClosed {
 			slog.Error("server error", "error", err)
 		}
-	}()
+	})
 
 	// Wait for shutdown signal
 	<-ctx.Done()


### PR DESCRIPTION
## Summary

- Replace bare `go func()` in `cmd/server/main.go:63` with `util.SafeGo()` for panic recovery on server startup goroutine
- Per project safety rules (`plan/v7/06-GO-SAFETY.md`): all goroutines must use `util.SafeGo()`

## Review Finding Addressed

- **PR #30 CodeRabbit**: bare goroutine violations across codebase

## Related Issues

- Partially addresses #59

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test -race -count=1 ./...` ✅