### PR TITLE
fix: use audio-only modality for native-audio Developer API

### DIFF
--- a/internal/handler/websocket_test.go
+++ b/internal/handler/websocket_test.go
@@ -15,9 +15,9 @@ func TestBuildOnboardingConfig(t *testing.T) {
 		t.Fatal("expected non-nil config")
 	}
 
-	// Check response modalities
-	if len(cfg.ResponseModalities) != 2 {
-		t.Fatalf("expected 2 modalities, got %d", len(cfg.ResponseModalities))
+	// Check response modalities — native-audio model is audio-only.
+	if len(cfg.ResponseModalities) != 1 {
+		t.Fatalf("expected 1 modality, got %d", len(cfg.ResponseModalities))
 	}
 
 	// Check voice config
@@ -61,33 +61,14 @@ func TestBuildOnboardingConfig(t *testing.T) {
 			t.Fatalf("expected tool %s in declarations", name)
 		}
 	}
-
-	// Check session resumption
-	if cfg.SessionResumption == nil {
-		t.Fatal("expected SessionResumption config")
-	}
-	// SessionResumption exists (Transparent removed for Developer API compatibility).
 }
 
 func TestBuildOnboardingConfig_Modalities(t *testing.T) {
 	mgr := session.NewManager("test-session")
 	cfg := mgr.BuildOnboardingConfig()
 
-	hasAudio := false
-	hasText := false
-	for _, m := range cfg.ResponseModalities {
-		if m == genai.ModalityAudio {
-			hasAudio = true
-		}
-		if m == genai.ModalityText {
-			hasText = true
-		}
-	}
-
-	if !hasAudio {
-		t.Fatal("expected AUDIO modality")
-	}
-	if !hasText {
-		t.Fatal("expected TEXT modality")
+	// Native-audio model requires audio-only output.
+	if len(cfg.ResponseModalities) != 1 || cfg.ResponseModalities[0] != genai.ModalityAudio {
+		t.Fatalf("expected AUDIO-only modality, got %v", cfg.ResponseModalities)
 	}
 }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -159,7 +159,7 @@ func (m *Manager) TransitionToReunion(ctx context.Context) error {
 // System voice: Aoede (missless host), warm guide in Korean.
 func (m *Manager) BuildOnboardingConfig() *genai.LiveConnectConfig {
 	return &genai.LiveConnectConfig{
-		ResponseModalities: []genai.Modality{genai.ModalityAudio, genai.ModalityText},
+		ResponseModalities: []genai.Modality{genai.ModalityAudio},
 		SpeechConfig: &genai.SpeechConfig{
 			VoiceConfig: &genai.VoiceConfig{
 				PrebuiltVoiceConfig: &genai.PrebuiltVoiceConfig{
@@ -189,7 +189,6 @@ Keep responses concise for voice — avoid long monologues.`),
 				FunctionDeclarations: onboardingTools(),
 			},
 		},
-		SessionResumption: &genai.SessionResumptionConfig{},
 	}
 }
 
@@ -215,7 +214,7 @@ func (m *Manager) BuildReunionConfig() *genai.LiveConnectConfig {
 	targetTokens := ContextTargetTokens
 
 	return &genai.LiveConnectConfig{
-		ResponseModalities: []genai.Modality{genai.ModalityAudio, genai.ModalityText},
+		ResponseModalities: []genai.Modality{genai.ModalityAudio},
 		SpeechConfig: &genai.SpeechConfig{
 			VoiceConfig: &genai.VoiceConfig{
 				PrebuiltVoiceConfig: &genai.PrebuiltVoiceConfig{
@@ -243,7 +242,6 @@ func (m *Manager) BuildReunionConfig() *genai.LiveConnectConfig {
 				FunctionDeclarations: reunionTools(),
 			},
 		},
-		SessionResumption: &genai.SessionResumptionConfig{},
 	}
 }
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -28,21 +28,9 @@ func TestManager_StartOnboarding_Config(t *testing.T) {
 			cfg.SpeechConfig.VoiceConfig.PrebuiltVoiceConfig.VoiceName)
 	}
 
-	// Must have Audio + Text modalities.
-	if len(cfg.ResponseModalities) != 2 {
-		t.Fatalf("expected 2 modalities, got %d", len(cfg.ResponseModalities))
-	}
-	hasAudio, hasText := false, false
-	for _, m := range cfg.ResponseModalities {
-		if m == genai.ModalityAudio {
-			hasAudio = true
-		}
-		if m == genai.ModalityText {
-			hasText = true
-		}
-	}
-	if !hasAudio || !hasText {
-		t.Fatal("expected both AUDIO and TEXT modalities")
+	// Must have Audio-only modality (native-audio model outputs audio only).
+	if len(cfg.ResponseModalities) != 1 || cfg.ResponseModalities[0] != genai.ModalityAudio {
+		t.Fatalf("expected AUDIO-only modality, got %v", cfg.ResponseModalities)
 	}
 
 	// System instruction must mention Korean greeting.
@@ -73,10 +61,6 @@ func TestManager_StartOnboarding_Config(t *testing.T) {
 		}
 	}
 
-	// Session resumption must be configured.
-	if cfg.SessionResumption == nil {
-		t.Fatal("expected session resumption config")
-	}
 }
 
 func TestManager_Transition_StateChange(t *testing.T) {


### PR DESCRIPTION
## Summary
- Remove `genai.ModalityText` from ResponseModalities — native-audio model outputs audio only
- Remove empty `SessionResumptionConfig{}` — Developer API rejects empty struct (reconnect.go handles it dynamically when a resumption token exists)
- Update tests in `manager_test.go` and `websocket_test.go` to expect audio-only modality

## Issue
Fixes "Request contains an invalid argument" (close 1007) error from Gemini Live API when connecting via Developer API with native-audio model.

## Root Cause
The `gemini-2.5-flash-native-audio-preview-12-2025` model on Developer API v1alpha:
1. Does not support `ModalityText` in `ResponseModalities` (audio-only output)
2. Rejects empty `SessionResumptionConfig{}` without a handle

## Local CI
- [x] go vet passed
- [x] go test -race passed (all packages)

## Test plan
- Deploy to Cloud Run and verify Live API WebSocket connection succeeds
- Verify audio streaming works end-to-end