### PR TITLE
fix: replace bare go func() with util.SafeGo (#53, #59)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -60,12 +60,12 @@ func main() {
 	}
 
 	// Start server
-	go func() {
+	util.SafeGo(func() {
 		slog.Info("server started", "port", cfg.Port)
 		if err := server.ListenAndServe(); err != http.ErrServerClosed {
 			slog.Error("server error", "error", err)
 		}
-	}()
+	})
 
 	// Wait for shutdown signal
 	<-ctx.Done()

--- a/internal/live/proxy.go
+++ b/internal/live/proxy.go
@@ -325,10 +325,10 @@ func (p *Proxy) sendBinary(data []byte) {
 // Wait blocks until all proxy goroutines have exited or the shutdown timeout elapses.
 func (p *Proxy) Wait() {
 	done := make(chan struct{})
-	go func() {
+	util.SafeGo(func() {
 		p.wg.Wait()
 		close(done)
-	}()
+	})
 
 	select {
 	case <-done:


### PR DESCRIPTION
## Summary
- Replace bare `go func()` in `proxy.go Wait()` with `util.SafeGo()` for panic recovery
- Replace bare `go func()` in `main.go` server start with `util.SafeGo()` for panic recovery
- Full grep audit confirms no remaining bare goroutines outside `safego.go` implementation and test files

## Issue
Closes #53
Closes #59

## Local CI
- [x] go vet passed
- [x] go test -race passed (all 14 packages)

## Test plan
- Existing proxy tests cover Wait() behavior
- Server startup goroutine panic recovery verified by SafeGo unit tests