### PR TITLE
fix(deploy): set PORT env and use it in Dockerfile healthcheck

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -35,9 +35,10 @@ ENV TZ=Asia/Seoul
 COPY --from=builder /server /server
 COPY --from=frontend /app/out /web/out
 
+ENV PORT=8080
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget -qO- http://localhost:8080/health || exit 1
+  CMD wget -qO- http://localhost:${PORT}/health || exit 1
 
 ENTRYPOINT ["/server"]


### PR DESCRIPTION
## Summary
- Add `ENV PORT=8080` as default in Dockerfile for Cloud Run compatibility
- Use `${PORT}` in `HEALTHCHECK CMD` instead of hardcoded `8080`
- Ensures healthcheck works correctly regardless of runtime PORT override

## Related Issues
Closes #57 — Dockerfile healthcheck port vs default port mismatch

## Impact
- No behavior change when PORT=8080 (Cloud Run default)
- Correctly follows PORT override if configured differently