### PR TITLE
fix(terraform): add Artifact Registry repo, API enables, and depends_on

### DIFF
--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -19,6 +19,39 @@ provider "google" {
   region  = var.region
 }
 
+# ── Required APIs ────────────────────────────────────────────
+
+resource "google_project_service" "run" {
+  service            = "run.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "artifactregistry" {
+  service            = "artifactregistry.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "firestore" {
+  service            = "firestore.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "secretmanager" {
+  service            = "secretmanager.googleapis.com"
+  disable_on_destroy = false
+}
+
+# ── Artifact Registry ────────────────────────────────────────
+
+resource "google_artifact_registry_repository" "missless" {
+  location      = var.region
+  repository_id = "missless"
+  format        = "DOCKER"
+  description   = "Docker images for missless.co backend"
+
+  depends_on = [google_project_service.artifactregistry]
+}
+
 # ── Service Account ──────────────────────────────────────────
 
 resource "google_service_account" "backend" {
@@ -47,6 +80,12 @@ resource "google_project_iam_member" "storage_admin" {
   member  = "serviceAccount:${google_service_account.backend.email}"
 }
 
+resource "google_project_iam_member" "secret_accessor" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.backend.email}"
+}
+
 # ── Cloud Firestore ──────────────────────────────────────────
 
 resource "google_firestore_database" "default" {
@@ -54,6 +93,8 @@ resource "google_firestore_database" "default" {
   name        = "(default)"
   location_id = var.region
   type        = "FIRESTORE_NATIVE"
+
+  depends_on = [google_project_service.firestore]
 }
 
 # ── Cloud Storage ────────────────────────────────────────────
@@ -100,6 +141,8 @@ resource "google_storage_bucket_iam_member" "albums_public" {
 resource "google_cloud_run_v2_service" "missless" {
   name     = "missless"
   location = var.region
+
+  depends_on = [google_project_service.run]
 
   template {
     service_account = google_service_account.backend.email


### PR DESCRIPTION
## Summary
- Add `google_artifact_registry_repository` resource for the `missless` Docker repo
- Enable required GCP APIs via `google_project_service`: Cloud Run, Artifact Registry, Firestore, Secret Manager
- Add `depends_on` chains to ensure proper resource creation ordering
- Add `secretmanager.secretAccessor` IAM role for backend service account
- Add `depends_on` for Firestore database resource

## Related Issues
Closes #51 — Container Registry vs Artifact Registry image path mismatch (Artifact Registry repo now explicitly created)
Closes #54 — Terraform missing Artifact Registry repository resource

## Impact
- `terraform apply` will now create the Artifact Registry repo before Cloud Build attempts to push images
- All required APIs are enabled automatically
- Proper dependency ordering prevents race conditions during `terraform apply`