### PR TITLE
fix: add authentication to WebSocket /ws endpoint

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -40,7 +40,7 @@ func main() {
 	mux := http.NewServeMux()
 	sessions := auth.NewSessionStore()
 	handler.RegisterHealth(mux)
-	handler.RegisterWebSocket(mux, cfg)
+	handler.RegisterWebSocket(mux, cfg, sessions)
 	handler.RegisterOAuth(mux, cfg, sessions)
 	handler.RegisterUpload(mux, cfg)
 

--- a/internal/handler/websocket.go
+++ b/internal/handler/websocket.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Two-Weeks-Team/missless/internal/auth"
 	"github.com/Two-Weeks-Team/missless/internal/config"
 	"github.com/Two-Weeks-Team/missless/internal/live"
 	"github.com/Two-Weeks-Team/missless/internal/retry"
@@ -33,13 +34,23 @@ func newUpgrader(cfg *config.Config) websocket.Upgrader {
 }
 
 // RegisterWebSocket registers the WebSocket endpoint for browser ↔ Go proxy.
-func RegisterWebSocket(mux *http.ServeMux, cfg *config.Config) {
+func RegisterWebSocket(mux *http.ServeMux, cfg *config.Config, sessions *auth.SessionStore) {
 	mux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
-		handleWebSocket(w, r, cfg)
+		handleWebSocket(w, r, cfg, sessions)
 	})
 }
 
-func handleWebSocket(w http.ResponseWriter, r *http.Request, cfg *config.Config) {
+func handleWebSocket(w http.ResponseWriter, r *http.Request, cfg *config.Config, sessions *auth.SessionStore) {
+	// Authenticate before WebSocket upgrade to prevent unauthorized Gemini API usage.
+	if cfg.IsProd() {
+		userSession := sessions.GetSessionFromRequest(r)
+		if userSession == nil {
+			slog.Warn("ws_auth_rejected", "remote", r.RemoteAddr)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+	}
+
 	up := newUpgrader(cfg)
 	conn, err := up.Upgrade(w, r, nil)
 	if err != nil {

--- a/internal/handler/websocket_test.go
+++ b/internal/handler/websocket_test.go
@@ -1,8 +1,12 @@
 package handler
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/Two-Weeks-Team/missless/internal/auth"
+	"github.com/Two-Weeks-Team/missless/internal/config"
 	"github.com/Two-Weeks-Team/missless/internal/session"
 	"google.golang.org/genai"
 )
@@ -70,5 +74,46 @@ func TestBuildOnboardingConfig_Modalities(t *testing.T) {
 	// Native-audio model requires audio-only output.
 	if len(cfg.ResponseModalities) != 1 || cfg.ResponseModalities[0] != genai.ModalityAudio {
 		t.Fatalf("expected AUDIO-only modality, got %v", cfg.ResponseModalities)
+	}
+}
+
+func TestWebSocket_AuthRequired_Prod(t *testing.T) {
+	sessions := auth.NewSessionStore()
+	cfg := &config.Config{
+		GeminiAPIKey: "test-key",
+		ProjectID:    "test-project",
+		Environment:  "production",
+		Domain:       "missless.co",
+	}
+
+	req := httptest.NewRequest("GET", "/ws", nil)
+	rec := httptest.NewRecorder()
+
+	handleWebSocket(rec, req, cfg, sessions)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for unauthenticated prod request, got %d", rec.Code)
+	}
+}
+
+func TestWebSocket_AuthSkipped_Dev(t *testing.T) {
+	sessions := auth.NewSessionStore()
+	cfg := &config.Config{
+		GeminiAPIKey: "test-key",
+		ProjectID:    "test-project",
+		Environment:  "development",
+		Domain:       "localhost",
+	}
+
+	req := httptest.NewRequest("GET", "/ws", nil)
+	rec := httptest.NewRecorder()
+
+	// In dev mode, auth is not required. The handler will proceed past auth
+	// and fail at WebSocket upgrade (since this isn't a real WS request),
+	// but it should NOT return 401.
+	handleWebSocket(rec, req, cfg, sessions)
+
+	if rec.Code == http.StatusUnauthorized {
+		t.Fatal("dev mode should not require authentication")
 	}
 }


### PR DESCRIPTION
## Summary
- Add session-based authentication to `/ws` WebSocket endpoint
- In production mode, verify `missless_session` cookie before WebSocket upgrade
- Return HTTP 401 before upgrade if unauthenticated (prevents Gemini API abuse)
- Dev mode (`ENVIRONMENT=development`) skips auth for local testing

## Issue
Closes #58

## Changes
- `internal/handler/websocket.go`: Accept `*auth.SessionStore`, check session before upgrade
- `cmd/server/main.go`: Pass `sessions` to `RegisterWebSocket`
- `internal/handler/websocket_test.go`: Add prod auth rejection + dev auth skip tests

## Local CI
- [x] go vet passed
- [x] go test -race passed (14 packages, 0 failures)

## Test plan
- Verify unauthenticated WebSocket connection is rejected in prod mode
- Verify authenticated WebSocket connection succeeds after OAuth login
- Verify dev mode allows connections without session cookie

🤖 Generated with [Claude Code](https://claude.com/claude-code)