### PR TITLE
feat: add IP-based rate limiting middleware

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -48,8 +48,10 @@ func main() {
 	fs := http.FileServer(http.Dir("web/out"))
 	mux.Handle("/", fs)
 
-	// Apply middleware
-	h := middleware.Recovery(middleware.Logging(mux))
+	// Apply middleware (outermost runs first)
+	// Rate limit: 10 req/s per IP, burst 20 — applies to all endpoints
+	limiter := middleware.NewIPRateLimiter(10, 20)
+	h := middleware.Recovery(middleware.Logging(middleware.RateLimit(limiter)(mux)))
 
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%s", cfg.Port),

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -1,0 +1,137 @@
+package middleware
+
+import (
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// visitor tracks request timestamps for a single IP.
+type visitor struct {
+	mu       sync.Mutex
+	tokens   float64
+	lastSeen time.Time
+	rate     float64 // tokens per second
+	burst    float64 // max tokens
+}
+
+func (v *visitor) allow() bool {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	now := time.Now()
+	elapsed := now.Sub(v.lastSeen).Seconds()
+	v.lastSeen = now
+
+	// Refill tokens
+	v.tokens += elapsed * v.rate
+	if v.tokens > v.burst {
+		v.tokens = v.burst
+	}
+
+	if v.tokens < 1 {
+		return false
+	}
+	v.tokens--
+	return true
+}
+
+// IPRateLimiter provides per-IP rate limiting.
+type IPRateLimiter struct {
+	mu       sync.RWMutex
+	visitors map[string]*visitor
+	rate     float64 // tokens per second
+	burst    float64
+	cleanup  time.Duration
+}
+
+// NewIPRateLimiter creates a rate limiter.
+// rate is requests per second, burst is the max burst size.
+func NewIPRateLimiter(rate float64, burst int) *IPRateLimiter {
+	rl := &IPRateLimiter{
+		visitors: make(map[string]*visitor),
+		rate:     rate,
+		burst:    float64(burst),
+		cleanup:  3 * time.Minute,
+	}
+	go rl.cleanupLoop()
+	return rl
+}
+
+func (rl *IPRateLimiter) getVisitor(ip string) *visitor {
+	rl.mu.RLock()
+	v, ok := rl.visitors[ip]
+	rl.mu.RUnlock()
+	if ok {
+		return v
+	}
+
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	// Double-check after write lock
+	if v, ok := rl.visitors[ip]; ok {
+		return v
+	}
+
+	v = &visitor{
+		tokens:   rl.burst,
+		lastSeen: time.Now(),
+		rate:     rl.rate,
+		burst:    rl.burst,
+	}
+	rl.visitors[ip] = v
+	return v
+}
+
+func (rl *IPRateLimiter) cleanupLoop() {
+	ticker := time.NewTicker(rl.cleanup)
+	defer ticker.Stop()
+	for range ticker.C {
+		rl.mu.Lock()
+		for ip, v := range rl.visitors {
+			v.mu.Lock()
+			if time.Since(v.lastSeen) > rl.cleanup {
+				delete(rl.visitors, ip)
+			}
+			v.mu.Unlock()
+		}
+		rl.mu.Unlock()
+	}
+}
+
+// RateLimit returns middleware that limits requests per IP.
+func RateLimit(limiter *IPRateLimiter) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ip := extractIP(r)
+			if !limiter.getVisitor(ip).allow() {
+				slog.Warn("rate_limited", "ip", ip, "path", r.URL.Path)
+				http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// extractIP returns the client IP from X-Forwarded-For (Cloud Run) or RemoteAddr.
+func extractIP(r *http.Request) string {
+	// Cloud Run sets X-Forwarded-For
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		// First IP in the chain is the client
+		for i := 0; i < len(xff); i++ {
+			if xff[i] == ',' {
+				return xff[:i]
+			}
+		}
+		return xff
+	}
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return ip
+}

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -1,0 +1,84 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRateLimit_AllowsBurst(t *testing.T) {
+	limiter := NewIPRateLimiter(1, 5) // 1 req/s, burst 5
+	handler := RateLimit(limiter)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// First 5 requests should succeed (burst).
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.RemoteAddr = "192.168.1.1:12345"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d: expected 200, got %d", i, rec.Code)
+		}
+	}
+
+	// 6th request should be rate limited.
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "192.168.1.1:12345"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 after burst, got %d", rec.Code)
+	}
+}
+
+func TestRateLimit_DifferentIPs(t *testing.T) {
+	limiter := NewIPRateLimiter(1, 1) // 1 req/s, burst 1
+	handler := RateLimit(limiter)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// IP 1: first request succeeds.
+	req1 := httptest.NewRequest("GET", "/test", nil)
+	req1.RemoteAddr = "10.0.0.1:1234"
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("IP1 first: expected 200, got %d", rec1.Code)
+	}
+
+	// IP 1: second request limited.
+	rec1b := httptest.NewRecorder()
+	handler.ServeHTTP(rec1b, req1)
+	if rec1b.Code != http.StatusTooManyRequests {
+		t.Fatalf("IP1 second: expected 429, got %d", rec1b.Code)
+	}
+
+	// IP 2: first request succeeds (independent).
+	req2 := httptest.NewRequest("GET", "/test", nil)
+	req2.RemoteAddr = "10.0.0.2:1234"
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("IP2: expected 200, got %d", rec2.Code)
+	}
+}
+
+func TestExtractIP_XForwardedFor(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Forwarded-For", "203.0.113.50, 70.41.3.18, 150.172.238.178")
+	ip := extractIP(req)
+	if ip != "203.0.113.50" {
+		t.Fatalf("expected first IP from XFF, got %q", ip)
+	}
+}
+
+func TestExtractIP_RemoteAddr(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "192.168.1.100:54321"
+	ip := extractIP(req)
+	if ip != "192.168.1.100" {
+		t.Fatalf("expected IP from RemoteAddr, got %q", ip)
+	}
+}


### PR DESCRIPTION
## Summary
- Add token bucket rate limiter middleware
- Per-IP tracking with automatic cleanup
- Cloud Run compatible via X-Forwarded-For
- 10 req/s per IP, burst 20

## Issue
Closes #60

## Local CI
- [x] go vet passed
- [x] go test -race passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)