### PR TITLE
fix(web): protocol-relative WebSocket URL + favicon

### DIFF
--- a/web/app/icon.svg
+++ b/web/app/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#1a1a2e"/>
+  <text x="16" y="23" text-anchor="middle" fill="#e94560" font-family="system-ui" font-weight="bold" font-size="22">M</text>
+</svg>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -107,7 +107,7 @@ export default function Home() {
   }, [transition]);
 
   const wsUrl = typeof window !== 'undefined'
-    ? `ws://${window.location.hostname}:${window.location.port || '18080'}/ws`
+    ? `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws`
     : '';
 
   const { state, connect, send, disconnect } = useWebSocket(wsUrl, handleMessage);


### PR DESCRIPTION
## Summary
- WebSocket URL이 HTTPS 페이지에서 `ws://` + 포트 `18080`으로 연결을 시도하여 Mixed Content 에러 발생
- `wss://` / `ws://`를 프로토콜에 따라 자동 선택하고, `window.location.host`를 사용하여 포트 문제 해결
- favicon.ico 404를 방지하기 위해 SVG 파비콘 추가

## Changes
- `web/app/page.tsx`: `ws://${hostname}:${port || '18080'}/ws` → `${protocol}://${host}/ws`
- `web/app/icon.svg`: 새 파비콘 파일

## Local CI
- [x] go vet passed
- [x] go test -race passed
- [x] tsc --noEmit passed
- [x] next lint passed

## Test plan
- [ ] HTTPS 환경에서 WebSocket 연결 → `wss://` 사용 확인
- [ ] 브라우저 콘솔에 Mixed Content 에러 없음
- [ ] favicon 정상 로딩 (404 없음)