### PR TITLE
fix(ws): allow WebSocket before OAuth login

### DIFF
--- a/internal/handler/websocket.go
+++ b/internal/handler/websocket.go
@@ -54,15 +54,9 @@ func RegisterWebSocket(mux *http.ServeMux, cfg *config.Config, sessions *auth.Se
 }
 
 func handleWebSocket(w http.ResponseWriter, r *http.Request, cfg *config.Config, sessions *auth.SessionStore) {
-	// Authenticate before WebSocket upgrade to prevent unauthorized Gemini API usage.
-	if cfg.IsProd() {
-		userSession := sessions.GetSessionFromRequest(r)
-		if userSession == nil {
-			slog.Warn("ws_auth_rejected", "remote", r.RemoteAddr)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-	}
+	// Protection: Origin check (in upgrader) + rate limiter + connection limit.
+	// Session auth is NOT required here because the onboarding flow connects
+	// the WebSocket before the user completes OAuth login.
 
 	// Application-level connection limit to prevent resource exhaustion.
 	if activeWSConns.Load() >= maxConcurrentWS {

--- a/internal/handler/websocket_test.go
+++ b/internal/handler/websocket_test.go
@@ -77,7 +77,9 @@ func TestBuildOnboardingConfig_Modalities(t *testing.T) {
 	}
 }
 
-func TestWebSocket_AuthRequired_Prod(t *testing.T) {
+func TestWebSocket_NoAuthRequired(t *testing.T) {
+	// WebSocket does NOT require session auth because the onboarding flow
+	// connects before OAuth login. Protection is via origin check + rate limit + connection limit.
 	sessions := auth.NewSessionStore()
 	cfg := &config.Config{
 		GeminiAPIKey: "test-key",
@@ -89,32 +91,12 @@ func TestWebSocket_AuthRequired_Prod(t *testing.T) {
 	req := httptest.NewRequest("GET", "/ws", nil)
 	rec := httptest.NewRecorder()
 
-	handleWebSocket(rec, req, cfg, sessions)
-
-	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("expected 401 for unauthenticated prod request, got %d", rec.Code)
-	}
-}
-
-func TestWebSocket_AuthSkipped_Dev(t *testing.T) {
-	sessions := auth.NewSessionStore()
-	cfg := &config.Config{
-		GeminiAPIKey: "test-key",
-		ProjectID:    "test-project",
-		Environment:  "development",
-		Domain:       "localhost",
-	}
-
-	req := httptest.NewRequest("GET", "/ws", nil)
-	rec := httptest.NewRecorder()
-
-	// In dev mode, auth is not required. The handler will proceed past auth
-	// and fail at WebSocket upgrade (since this isn't a real WS request),
-	// but it should NOT return 401.
+	// Should NOT return 401 — proceeds to WebSocket upgrade (which fails in test
+	// since this isn't a real WS request, but the point is no auth rejection).
 	handleWebSocket(rec, req, cfg, sessions)
 
 	if rec.Code == http.StatusUnauthorized {
-		t.Fatal("dev mode should not require authentication")
+		t.Fatal("WebSocket should not require session authentication")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Production에서 WebSocket 연결 시 세션 쿠키 인증이 필수였으나, 온보딩 플로우에서는 OAuth 로그인 전에 WebSocket이 먼저 연결됨
- 세션 인증 제거 — Origin 검사 + Rate limiting + Connection limit으로 보호 유지

## Root Cause
```
User clicks Start → WebSocket tries to connect → 401 Unauthorized (no session cookie)
```
온보딩 플로우: Start → WS 연결 → 온보딩 진행 → OAuth 로그인 (나중)

## Protection Stack (auth 제거 후에도 유지)
- Origin check: `missless.co` 도메인만 허용 (prod)
- Rate limiting: 10 req/s per IP, burst 20
- Connection limit: max 20 concurrent WebSocket sessions

## Local CI
- [x] go vet passed
- [x] go test -race passed (all 14 packages)

## Test plan
- [ ] 프로덕션에서 로그인 없이 WebSocket 연결 성공
- [ ] 브라우저 콘솔에 연결 에러 없음