### PR TITLE
ci: path filter to skip unrelated jobs on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@
 # missless — CI Pipeline
 # Go: vet, staticcheck, race-detected tests, build
 # Frontend: type-check, lint, build (Next.js static export)
+# Path filter: skip unrelated jobs on PRs (push to main runs all)
 # ============================================================
 
 name: CI
@@ -17,8 +18,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+      web: ${{ steps.filter.outputs.web }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            go:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - '.github/workflows/ci.yml'
+            web:
+              - 'web/**'
+              - '.github/workflows/ci.yml'
+
   go-ci:
     name: Go CI
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -50,6 +76,8 @@ jobs:
 
   frontend-ci:
     name: Frontend CI
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:


### PR DESCRIPTION
## Summary
- PR에서 변경되지 않은 스택의 CI job을 스킵하여 불필요한 실행 감소
- \`dorny/paths-filter@v3\` 사용

## How it works
| 변경 파일 | Go CI | Frontend CI |
|-----------|-------|-------------|
| \`*.go\`, \`go.mod\` | ✅ 실행 | ❌ 스킵 |
| \`web/**\` | ❌ 스킵 | ✅ 실행 |
| \`.github/workflows/ci.yml\` | ✅ 실행 | ✅ 실행 |
| Push to main | ✅ 항상 실행 | ✅ 항상 실행 |

## Expected savings
- web/ 변경만 있는 PR: Go CI 55초 절약
- Go 변경만 있는 PR: Frontend CI 40초 절약

## Test plan
- [ ] web/ 파일만 변경 → Go CI 스킵 확인
- [ ] Go 파일만 변경 → Frontend CI 스킵 확인
- [ ] ci.yml 변경 → 양쪽 모두 실행 확인