### PR TITLE
fix: allow same-origin WebSocket in production

### DIFF
--- a/internal/handler/websocket.go
+++ b/internal/handler/websocket.go
@@ -41,7 +41,18 @@ func newUpgrader(cfg *config.Config) websocket.Upgrader {
 				return true
 			}
 			origin := r.Header.Get("Origin")
-			return origin == "" || strings.HasSuffix(origin, cfg.Domain)
+			if origin == "" {
+				return true
+			}
+			// Allow configured domain (e.g. missless.co)
+			if strings.HasSuffix(origin, cfg.Domain) {
+				return true
+			}
+			// Allow same-origin (e.g. Cloud Run auto-generated URL)
+			if strings.Contains(origin, r.Host) {
+				return true
+			}
+			return false
 		},
 	}
 }

--- a/internal/handler/websocket_test.go
+++ b/internal/handler/websocket_test.go
@@ -100,6 +100,43 @@ func TestWebSocket_NoAuthRequired(t *testing.T) {
 	}
 }
 
+func TestUpgrader_OriginCheck(t *testing.T) {
+	cfg := &config.Config{
+		GeminiAPIKey: "test-key",
+		ProjectID:    "test-project",
+		Environment:  "production",
+		Domain:       "missless.co",
+	}
+	up := newUpgrader(cfg)
+
+	tests := []struct {
+		name   string
+		origin string
+		host   string
+		want   bool
+	}{
+		{"empty origin", "", "example.com", true},
+		{"custom domain", "https://missless.co", "missless.co", true},
+		{"custom subdomain", "https://www.missless.co", "www.missless.co", true},
+		{"same-origin cloud run", "https://missless-abc-du.a.run.app", "missless-abc-du.a.run.app", true},
+		{"foreign origin", "https://evil.com", "missless-abc-du.a.run.app", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/ws", nil)
+			req.Host = tt.host
+			if tt.origin != "" {
+				req.Header.Set("Origin", tt.origin)
+			}
+			got := up.CheckOrigin(req)
+			if got != tt.want {
+				t.Fatalf("CheckOrigin(%q, host=%q) = %v, want %v", tt.origin, tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWebSocket_ConnectionLimit(t *testing.T) {
 	// Verify that ActiveWSCount starts at 0.
 	if ActiveWSCount() != 0 {


### PR DESCRIPTION
## Summary
- WebSocket origin check now accepts same-origin requests (Origin matches Host header)
- Fixes 403 on Cloud Run auto-generated URL (`missless-umbzc4227a-du.a.run.app`)
- Still rejects foreign origins in production

## Issue
WebSocket connection returned 403 because `https://missless-umbzc4227a-du.a.run.app` doesn't end with `missless.co` (the configured DOMAIN).

## Local CI
- [x] go vet passed
- [x] go test -race passed (all 12 packages)

## Test plan
- Deploy to Cloud Run
- Navigate to Cloud Run URL
- Click "시작하기" — WebSocket should connect (no 403)