### PR TITLE
fix: proxy Wait blocks for session lifetime

### DIFF
--- a/internal/live/proxy.go
+++ b/internal/live/proxy.go
@@ -331,23 +331,15 @@ func (p *Proxy) sendBinary(data []byte) {
 	}
 }
 
-// Wait blocks until all proxy goroutines have exited or the shutdown timeout elapses.
+// Wait blocks until all proxy goroutines have exited.
+// Use this in the handler to keep the session alive for its full lifetime.
 func (p *Proxy) Wait() {
-	wgDone := make(chan struct{}, 1)
-	util.SafeGo(func() {
-		p.wg.Wait()
-		close(wgDone)
-	})
-
-	select {
-	case <-wgDone:
-		slog.Info("proxy_goroutines_exited")
-	case <-time.After(shutdownTimeout):
-		slog.Warn("proxy_shutdown_timeout")
-	}
+	p.wg.Wait()
+	slog.Info("proxy_goroutines_exited")
 }
 
-// Close terminates the proxy, closes the live session, and waits for goroutines.
+// Close terminates the proxy, closes the live session, and waits for goroutines
+// with a bounded timeout to prevent hanging during shutdown.
 func (p *Proxy) Close() {
 	p.mu.Lock()
 	if p.closed {
@@ -365,5 +357,16 @@ func (p *Proxy) Close() {
 		old.Close()
 	}
 
-	p.Wait()
+	wgDone := make(chan struct{}, 1)
+	util.SafeGo(func() {
+		p.wg.Wait()
+		close(wgDone)
+	})
+
+	select {
+	case <-wgDone:
+		slog.Info("proxy_goroutines_exited")
+	case <-time.After(shutdownTimeout):
+		slog.Warn("proxy_shutdown_timeout")
+	}
 }


### PR DESCRIPTION
## Summary
- `Wait()` now blocks indefinitely until proxy goroutines exit (browser disconnect/error)
- Bounded 5s timeout kept only in `Close()` for graceful shutdown
- Fixes WebSocket sessions dying after 5 seconds regardless of activity

## Root cause
`proxy.Wait()` used a 5s `shutdownTimeout`, but was called in the handler to keep the session alive. Every session was killed after exactly 5 seconds.

## Local CI
- [x] go vet passed
- [x] go test -race passed (all 12 packages)

## Test plan
- Deploy to Cloud Run
- Click "시작하기" — session should stay connected beyond 5s
- AI greeting audio should arrive at browser