### PR TITLE
fix: enable proactive audio for onboarding greeting

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -158,6 +158,7 @@ func (m *Manager) TransitionToReunion(ctx context.Context) error {
 // BuildOnboardingConfig creates the LiveConnectConfig for the onboarding phase.
 // System voice: Aoede (missless host), warm guide in Korean.
 func (m *Manager) BuildOnboardingConfig() *genai.LiveConnectConfig {
+	enableProactive := true
 	return &genai.LiveConnectConfig{
 		ResponseModalities: []genai.Modality{genai.ModalityAudio},
 		SpeechConfig: &genai.SpeechConfig{
@@ -166,6 +167,9 @@ func (m *Manager) BuildOnboardingConfig() *genai.LiveConnectConfig {
 					VoiceName: "Aoede",
 				},
 			},
+		},
+		Proactivity: &genai.ProactivityConfig{
+			ProactiveAudio: &enableProactive,
 		},
 		SystemInstruction: &genai.Content{
 			Parts: []*genai.Part{


### PR DESCRIPTION
## Summary
- Enable `ProactiveAudio` in the onboarding Live API config
- AI will greet the user first without waiting for speech input

## Root cause
Native audio model with `ModalityAudio` waits for user speech before responding. Without `ProactiveAudio`, the onboarding greeting never fires — creating an awkward silence after clicking "시작하기".

## Local CI
- [x] go vet passed
- [x] go test -race passed (all 12 packages)

## Test plan
- Deploy to Cloud Run
- Click "시작하기" — AI should begin speaking within seconds
- Verify audio PCM data arrives over WebSocket

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 온보딩 중 사전 예방적 오디오 기능이 활성화되었습니다. 사용자는 이제 온보딩 프로세스 중에 향상된 오디오 경험을 받을 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->