### PR TITLE
fix: send initial greeting trigger after Live API setup

### DIFF
--- a/internal/handler/websocket.go
+++ b/internal/handler/websocket.go
@@ -133,6 +133,16 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request, cfg *config.Config,
 	proxy.SetReconnectParams(client, LiveModel, liveConfig)
 	proxy.Run(ctx)
 
+	// Send initial greeting trigger so the model speaks first.
+	err = liveSession.SendClientContent(genai.LiveClientContentInput{
+		Turns: []*genai.Content{
+			genai.NewContentFromText("(사용자가 방금 접속했습니다. 따뜻하게 인사해주세요.)", "user"),
+		},
+	})
+	if err != nil {
+		slog.Error("initial_greeting_failed", "error", err)
+	}
+
 	slog.Info("session_started",
 		"remote", r.RemoteAddr,
 		"state", string(mgr.State()),


### PR DESCRIPTION
## Summary
- Send `SendClientContent` with greeting prompt after Live API setup completes
- Triggers the AI to start speaking immediately when user connects

## Root cause
Native audio model waits for user input before responding. Even with ProactiveAudio enabled, it doesn't initiate without content. Sending an initial client content message triggers the greeting.

## Local CI
- [x] go vet passed
- [x] go test -race passed (all 12 packages)

## Test plan
- Deploy to Cloud Run
- Click "시작하기" — AI should start speaking greeting within seconds
- Verify binary audio frames arrive in WebSocket