### PR TITLE
fix: goroutine cleanup on browser disconnect

### DIFF
--- a/internal/live/proxy.go
+++ b/internal/live/proxy.go
@@ -41,6 +41,7 @@ type Proxy struct {
 	mu            sync.Mutex
 	wg            sync.WaitGroup
 	done          chan struct{}
+	shutdownOnce  sync.Once // ensures initiateShutdown runs exactly once
 	sendToBrowser chan []byte
 	started       bool // guards against duplicate Run calls
 	closed        bool // guards against duplicate Close calls
@@ -69,6 +70,24 @@ func (p *Proxy) SetReconnectParams(client *genai.Client, model string, config *g
 	p.liveConfig = config
 }
 
+// initiateShutdown closes the done channel and live session exactly once,
+// signaling all goroutines to exit. It does NOT wait for goroutines (safe to
+// call from within a goroutine without deadlock).
+func (p *Proxy) initiateShutdown() {
+	p.shutdownOnce.Do(func() {
+		p.mu.Lock()
+		sess := p.liveSession
+		p.liveSession = nil
+		p.mu.Unlock()
+
+		close(p.done)
+
+		if sess != nil {
+			sess.Close()
+		}
+	})
+}
+
 // Run starts the bidirectional proxy forwarding goroutines.
 func (p *Proxy) Run(ctx context.Context) {
 	p.mu.Lock()
@@ -85,10 +104,12 @@ func (p *Proxy) Run(ctx context.Context) {
 	util.SafeGo(func() {
 		defer p.wg.Done()
 		p.forwardBrowserToLive(ctx)
+		p.initiateShutdown() // browser disconnect → unblock siblings
 	})
 	util.SafeGo(func() {
 		defer p.wg.Done()
 		p.forwardLiveToBrowser(ctx)
+		p.initiateShutdown() // live API error → unblock siblings
 	})
 	util.SafeGo(func() {
 		defer p.wg.Done()
@@ -169,6 +190,8 @@ func (p *Proxy) forwardBrowserToLive(ctx context.Context) {
 
 // forwardLiveToBrowser reads from Live API and sends to browser.
 func (p *Proxy) forwardLiveToBrowser(ctx context.Context) {
+	consecutiveErrors := 0
+	const maxConsecutiveErrors = 3
 	for {
 		select {
 		case <-ctx.Done():
@@ -180,6 +203,8 @@ func (p *Proxy) forwardLiveToBrowser(ctx context.Context) {
 
 		session := p.getSession()
 		if session == nil {
+			// Session may be nil during SwapSession — wait for new one.
+			consecutiveErrors = 0
 			time.Sleep(sessionPollInterval)
 			continue
 		}
@@ -193,10 +218,18 @@ func (p *Proxy) forwardLiveToBrowser(ctx context.Context) {
 				return
 			default:
 			}
-			slog.Error("live_receive_error", "error", err)
-			return
+			consecutiveErrors++
+			if consecutiveErrors > maxConsecutiveErrors {
+				slog.Error("live_receive_fatal", "error", err, "consecutive", consecutiveErrors)
+				return
+			}
+			// May be a transient error from SwapSession closing old session — retry.
+			slog.Warn("live_receive_error", "error", err, "consecutive", consecutiveErrors)
+			time.Sleep(sessionPollInterval)
+			continue
 		}
 
+		consecutiveErrors = 0
 		p.handleLiveMessage(ctx, msg)
 	}
 }
@@ -347,15 +380,9 @@ func (p *Proxy) Close() {
 		return
 	}
 	p.closed = true
-	old := p.liveSession
-	p.liveSession = nil
 	p.mu.Unlock()
 
-	close(p.done)
-
-	if old != nil {
-		old.Close()
-	}
+	p.initiateShutdown()
 
 	wgDone := make(chan struct{}, 1)
 	util.SafeGo(func() {


### PR DESCRIPTION
## Summary
- Add `initiateShutdown()` with `sync.Once` to safely close done channel + live session when any reader goroutine exits
- When browser disconnects, `forwardBrowserToLive` now triggers `initiateShutdown()` which unblocks `session.Receive()` in `forwardLiveToBrowser`
- `forwardLiveToBrowser` now retries on Receive errors (up to 3) to survive transient errors during `SwapSession`
- `Close()` delegates to `initiateShutdown()` instead of duplicating channel/session close logic

## Issue
After browser disconnect, `forwardLiveToBrowser` stays blocked on `session.Receive()` indefinitely because:
1. `done` channel isn't closed yet (Close runs after Wait)
2. Context isn't cancelled yet (cancel runs after Wait)
3. Live session isn't closed (only happens in Close)

This causes `proxy.Wait()` to never return → handler never exits → `activeWSConns` counter never decrements → goroutine leak.

## Test plan
- [x] `go test -race ./internal/live/...` — all pass
- [x] `go test -race ./...` — all pass
- [x] `go vet ./...` — clean
- [ ] Deploy and verify connections clean up after browser disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 세션 종료 처리 개선으로 더욱 안정적인 동작 보장
  * 일시적 오류에 대한 자동 재시도 기능 추가
  * 세션 관리 및 연결 유지 신뢰성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->