### PR TITLE
fix: address PR #118 review comments for generate-bgm tests

### DIFF
--- a/cmd/generate-bgm/main_test.go
+++ b/cmd/generate-bgm/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -388,10 +389,7 @@ func TestWSEndpoint(t *testing.T) {
 		t.Fatal("wsEndpoint should not be empty")
 	}
 	// Must use secure WebSocket.
-	if len(wsEndpoint) < 4 {
-		t.Fatalf("wsEndpoint too short to contain scheme: %q", wsEndpoint)
-	}
-	if wsEndpoint[:4] != "wss:" {
+	if !strings.HasPrefix(wsEndpoint, "wss:") {
 		t.Errorf("wsEndpoint should use wss:// scheme, got: %s", wsEndpoint)
 	}
 }


### PR DESCRIPTION
## Summary
- Check `json.Marshal` error return instead of discarding with `_` in `TestWeightedPrompt_JSONTags`
- Add length guard before `wsEndpoint[:4]` slice to prevent runtime panic if string is shorter than 4 characters

## Issue
Follow-up from PR #118 CodeRabbit review comments

## Local CI
- [x] `go test -race -count=1 ./...` passed (all packages)
- [x] `go vet ./...` passed

## Test plan
- All existing generate-bgm tests pass with race detector enabled
- `TestWeightedPrompt_JSONTags` now properly checks marshal error
- `TestWSEndpoint` safely guards against short endpoint strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* JSON 마샬링 오류 처리를 개선하여 테스트 신뢰성 향상
* 엔드포인트 길이 유효성 검사 로직 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->